### PR TITLE
Improving maps preview in SS

### DIFF
--- a/code/styles/Map.css
+++ b/code/styles/Map.css
@@ -5,6 +5,19 @@
     width: 100%;
 }
 
+/* 
+* This pseudo element, will force the .map-wrapper to occupy all the possibly width.
+* This is specially important when insidethe map is inside an if and an inline map
+* key is passed. 
+*/
+.map-wrapper:before {
+    -servicestudio-content: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
+    -servicestudio-display: block;
+    -servicestudio-height: 0;
+    -servicestudio-overflow: hidden;
+    -servicestudio-word-break: break-all;
+}
+
 .map-wrapper.is--hidden {
     opacity: 0;
     -servicestudio-opacity: 1;


### PR DESCRIPTION
When a map is added to the page inside an if, and a key is passed as a parameter, the map preview was being severely affected (see image below):
![map-preview-problems](https://user-images.githubusercontent.com/10534623/123092201-e75cbd00-d432-11eb-8228-2182e12703e4.gif)


### What was happening
* Preview was broken when in an if, and a key is passed

### What was done
* Added a pseudo element for SS only, that will force the width to grow.

### Screenshots
![map-preview-improvement-2](https://user-images.githubusercontent.com/10534623/123091721-5a196880-d432-11eb-8e6c-a26625c7a0f8.gif)

### Checklist
* [x] tested locally
* [x] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

### Special Kudos
* To James Harrison for reporting the situation
* To @joselrio for helping to find an elegant solution

