### PR TITLE
RGRIDT-984: OutSystems Maps not working correctly when a Japanese address is provided

### DIFF
--- a/code/src/GoogleProvider/Helper/Conversions.ts
+++ b/code/src/GoogleProvider/Helper/Conversions.ts
@@ -11,7 +11,6 @@ namespace GoogleProvider.Helper.Conversions {
         location: string,
         apiKey: string
     ): Promise<OSFramework.OSStructures.OSMap.Coordinates> {
-        location = location.replace(/[^a-zA-Z0-9 ]/g, '');
         return fetch(
             `${OSFramework.Helper.Constants.googleMapsApiGeocode}?address=${location}&key=${apiKey}`
         )
@@ -52,11 +51,13 @@ namespace GoogleProvider.Helper.Conversions {
             });
         }
 
-        // If the location doesn't have any chars a-z A-Z
-        if (location.search(/[a-zA-Z]/g) === -1) {
+        // Regex that validates if string is a set of coordinates
+        const regexValidator = /^-{0,1}\d*\.{0,1}\d*,-{0,1}\d*\.{0,1}\d*$/;
+        // If the provided location is a set of coordinates
+        if (regexValidator.test(location)) {
             let latitude: number;
             let longitude: number;
-            // If the location is a set of coordinates
+            // split the coordinates into latitude and longitude
             if (location.indexOf(',') > -1) {
                 latitude = parseFloat(location.split(',')[0].replace(' ', ''));
                 longitude = parseFloat(location.split(',')[1].replace(' ', ''));


### PR DESCRIPTION
This PR is for RGRIDT-984: OutSystems Maps not working correctly when a Japanese address is provided

### What was happening
* There was a bug in production related to the conversion of addresses into coordinates. It's not possible to use Japanese characters as locations. E.g. "東京都港区芝公園４丁目２−８" would not work.

### What was done
* We were converting the addresses to coordinates but only to chars [a-zA-Z0-9 ] which made it impossible to have locations in other languages like Japanese, etc.

### Test Steps
To test the new REGEX that validates if the location is in fact a set of coordinates: [regex](https://regex101.com/r/gaZ2b9/1)

1) Try to set the location of the Map to "東京都港区芝公園４丁目２−８"
**Expected: The map should get centered near Tokyo.**

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes) - NA
* [ ] requires new sample page in OutSystems (if so, provide a module with changes) - NA