### PR TITLE
RGRIDT-915: Update CSS of FileLayer preview

### DIFF
--- a/code/styles/Map.css
+++ b/code/styles/Map.css
@@ -605,6 +605,7 @@ html[data-uieditorversion^="1"]:hover .map-preview-events:empty:after {
     -servicestudio-margin: 3px;
     -servicestudio-max-width: 200px;
     -servicestudio-min-width: 200px;
+    -servicestudio-padding-bottom: 10px;
 }
 
 .ss-fileLayer-icon{


### PR DESCRIPTION
This PR is for RGRIDT-915: Update CSS of FileLayer preview

### What was happening
* There was a small error on the preview of the File Layer block in SS.

### What was done
* Added a padding-bottom to the css file.
 

### Screenshots
Before: 
![image](https://user-images.githubusercontent.com/6432232/134930098-eb939e56-2c28-4ffb-9617-9a5a2b9d5ea7.png)

After:
![image](https://user-images.githubusercontent.com/6432232/134930174-8bd72573-b164-49c5-b5ea-43e08c0e6200.png)


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
