### PR TITLE
RGRIDT-1014: Fixing bug when disposing the map (drawingTools doesn't exist)

### DIFF
--- a/code/src/OSFramework/OSMap/AbstractMap.ts
+++ b/code/src/OSFramework/OSMap/AbstractMap.ts
@@ -153,7 +153,8 @@ namespace OSFramework.OSMap {
                 this.removeShape(shapeId);
             });
             // Let's make sure we remove the DrawingTools from the map
-            this.removeDrawingTools(this.drawingTools.uniqueId);
+            this.drawingTools &&
+                this.removeDrawingTools(this.drawingTools.uniqueId);
         }
 
         public equalsToID(mapId: string): boolean {


### PR DESCRIPTION
This PR is for RGRIDT-1014: Fixing bug when disposing the map (drawingTools doesn't exist)

### What was happening
* When destroying the map we are removing all markers, shapes and drawing tools. But the component is trying to remove the drawing tools object when it doesn't exist.

### What was done
* We are now checking if the drawing tools exist before removing it.

### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

