### PR TITLE
RGRIDT-996: SearchPlace (search autocomplete) | part 4 (Events)

### DIFF
--- a/code/src/OSFramework/Event/SearchPlaces/AbstractSearchPlacesEvent.ts
+++ b/code/src/OSFramework/Event/SearchPlaces/AbstractSearchPlacesEvent.ts
@@ -1,0 +1,33 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Event.SearchPlaces {
+    /**
+     * Class that will make sure that the trigger invokes the handlers
+     * with the correct parameters.
+     *
+     * @abstract
+     * @class AbstractShapeEvent
+     * @extends {AbstractEvent<string>}
+     */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    export abstract class AbstractSearchPlacesEvent extends AbstractEvent<OSFramework.SearchPlaces.ISearchPlaces> {
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+        public trigger(
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            searchPlacesObj: OSFramework.SearchPlaces.ISearchPlaces,
+            searchPlacesId: string,
+            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+            ...args: any
+        ): void {
+            this.handlers
+                .slice(0)
+                .forEach((h) =>
+                    Helper.AsyncInvocation(
+                        h,
+                        searchPlacesObj,
+                        searchPlacesId,
+                        ...args
+                    )
+                );
+        }
+    }
+}

--- a/code/src/OSFramework/Event/SearchPlaces/SearchPlacesEventType.enum.ts
+++ b/code/src/OSFramework/Event/SearchPlaces/SearchPlacesEventType.enum.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Event.SearchPlaces {
+    /**
+     * Events currently supported in the SearchPlaces element.
+     *
+     * @export
+     * @enum {string}
+     */
+    export enum SearchPlacesEventType {
+        Initialized = 'Initialized',
+        OnError = 'OnError',
+        OnPlaceSelect = 'OnPlaceSelect'
+    }
+}

--- a/code/src/OSFramework/Event/SearchPlaces/SearchPlacesEventsManager.ts
+++ b/code/src/OSFramework/Event/SearchPlaces/SearchPlacesEventsManager.ts
@@ -1,0 +1,126 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Event.SearchPlaces {
+    /**
+     * Class that will be responsible for managing the events of the SearchPlaces.
+     *
+     * @export
+     * @class SearchPlacesEventsManager
+     * @extends {AbstractEventsManager<SearchPlacesEventType, OSFramework.SearchPlaces.ISearchPlaces>}
+     */
+    export class SearchPlacesEventsManager extends AbstractEventsManager<
+        SearchPlacesEventType,
+        OSFramework.SearchPlaces.ISearchPlaces
+    > {
+        private _searchPlaces: OSFramework.SearchPlaces.ISearchPlaces;
+
+        constructor(searchPlaces: OSFramework.SearchPlaces.ISearchPlaces) {
+            super();
+            this._searchPlaces = searchPlaces;
+        }
+
+        protected getInstanceOfEventType(
+            eventType: SearchPlacesEventType
+        ): OSFramework.Event.IEvent<OSFramework.SearchPlaces.ISearchPlaces> {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            let event: OSFramework.Event.IEvent<OSFramework.SearchPlaces.ISearchPlaces>;
+
+            switch (eventType) {
+                case SearchPlacesEventType.Initialized:
+                    event = new SearchPlacesInitializedEvent();
+                    break;
+                case SearchPlacesEventType.OnError:
+                    event = new SearchPlacesOnError();
+                    break;
+                case SearchPlacesEventType.OnPlaceSelect:
+                    event = new SearchPlacesOnPlaceSelect();
+                    break;
+                default:
+                    this._searchPlaces.searchPlacesEvents.trigger(
+                        SearchPlaces.SearchPlacesEventType.OnError,
+                        this._searchPlaces,
+                        Enum.ErrorCodes.GEN_UnsupportedEventSearchPlaces,
+                        `${eventType}`
+                    );
+                    return;
+            }
+            return event;
+        }
+
+        public addHandler(
+            eventType: SearchPlacesEventType,
+            handler: Callbacks.SearchPlaces.Event
+        ): void {
+            //if the SearchPlaces is already ready, fire immediatly the event.
+            if (
+                eventType === SearchPlacesEventType.Initialized &&
+                this._searchPlaces.isReady
+            ) {
+                //make the invocation of the handler assync.
+                Helper.AsyncInvocation(
+                    handler,
+                    this._searchPlaces,
+                    this._searchPlaces.widgetId
+                );
+            } else {
+                super.addHandler(eventType, handler);
+            }
+        }
+
+        /**
+         * Trigger the specific events depending on the event type specified
+         * @param eventType Type of the event currently supported in the SearchPlaces element.
+         * @param value Value to be passed to OS in the type of a string.
+         */
+        public trigger(
+            eventType: SearchPlacesEventType,
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            searchPlaces?: OSFramework.SearchPlaces.ISearchPlaces,
+            eventInfo?: string,
+            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+            ...args: any
+        ): void {
+            // Check if the FileLayer has any events associated
+            if (this.handlers.has(eventType)) {
+                const handlerEvent = this.handlers.get(eventType);
+
+                switch (eventType) {
+                    case SearchPlacesEventType.Initialized:
+                        handlerEvent.trigger(
+                            this._searchPlaces, // SearchPlaces Object that was initialized
+                            this._searchPlaces.widgetId ||
+                                this._searchPlaces.uniqueId // Id of SearchPlaces block that was initialized
+                        );
+                        break;
+                    case SearchPlacesEventType.OnError:
+                        handlerEvent.trigger(
+                            this._searchPlaces, // SearchPlaces Object that had the error
+                            this._searchPlaces.widgetId ||
+                                this._searchPlaces.uniqueId, // Id of SearchPlaces block that had the error
+                            eventInfo, // Error Code
+                            args[0] // Extra Error messages that might come from the Provider APIs (geocoding for instance)
+                        );
+                        break;
+                    case SearchPlacesEventType.OnPlaceSelect:
+                        handlerEvent.trigger(
+                            this._searchPlaces, // SearchPlaces Object where the place selection occurred.
+                            this._searchPlaces.widgetId ||
+                                this._searchPlaces.uniqueId, // Id of SearchPlaces block that was clicked
+                            args[0].name, // name of the place selected
+                            args[0].coordinates, // coordinates of the place selected
+                            args[0].address // full address of the place selected
+                        );
+                        break;
+                    // If the event is not valid we can fall in the default case of the switch and throw an error
+                    default:
+                        this._searchPlaces.searchPlacesEvents.trigger(
+                            SearchPlaces.SearchPlacesEventType.OnError,
+                            this._searchPlaces,
+                            Enum.ErrorCodes.GEN_UnsupportedEventSearchPlaces,
+                            `${eventType}`
+                        );
+                        return;
+                }
+            }
+        }
+    }
+}

--- a/code/src/OSFramework/Event/SearchPlaces/SearchPlacesInitializedEvent.ts
+++ b/code/src/OSFramework/Event/SearchPlaces/SearchPlacesInitializedEvent.ts
@@ -1,0 +1,12 @@
+///<reference path="AbstractSearchPlacesEvent.ts"/>
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Event.SearchPlaces {
+    /**
+     * Class that represents the the Initialized event.
+     *
+     * @class SearchPlacesInitializedEvent
+     * @extends {AbstractEvent<OSFramework.SearchPlaces.ISearchPlaces>}
+     */
+    export class SearchPlacesInitializedEvent extends AbstractSearchPlacesEvent {}
+}

--- a/code/src/OSFramework/Event/SearchPlaces/SearchPlacesOnError.ts
+++ b/code/src/OSFramework/Event/SearchPlaces/SearchPlacesOnError.ts
@@ -1,0 +1,39 @@
+///<reference path="AbstractSearchPlacesEvent.ts"/>
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Event.SearchPlaces {
+    /**
+     * Class that represents the the Initialized event.
+     *
+     * @class SearchPlacesOnError
+     * @extends {AbstractEvent<OSFramework.OSSearchPlaces.ISearchPlaces>}
+     */
+    export class SearchPlacesOnError extends AbstractSearchPlacesEvent {
+        /**
+         * Method that will trigger the event with the correct parameters.
+         * @param searchPlacesObj SearchPlaces that is raising the event
+         * @param searchPlacesId Id of the SearchPlaces that is raising the event
+         * @param eventName Name of the event that got raised
+         * @param errorMessage Extra error messages that might come from errors that occurred using the Provider APIs
+         */
+        public trigger(
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            searchPlacesObj: OSFramework.SearchPlaces.ISearchPlaces,
+            searchPlacesId: string,
+            eventName: string,
+            errorMessage?: string
+        ): void {
+            this.handlers
+                .slice(0)
+                .forEach((h) =>
+                    Helper.AsyncInvocation(
+                        h,
+                        searchPlacesObj,
+                        searchPlacesId,
+                        eventName,
+                        errorMessage
+                    )
+                );
+        }
+    }
+}

--- a/code/src/OSFramework/Event/SearchPlaces/SearchPlacesOnPlaceSelect.ts
+++ b/code/src/OSFramework/Event/SearchPlaces/SearchPlacesOnPlaceSelect.ts
@@ -1,0 +1,12 @@
+///<reference path="AbstractSearchPlacesEvent.ts"/>
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Event.SearchPlaces {
+    /**
+     * Class that represents the PlaceSelect event
+     *
+     * @class SearchPlacesOnPlaceSelect
+     * @extends {AbstractEvent<OSFramework.SearchPlaces.ISearchPlaces>}
+     */
+    export class SearchPlacesOnPlaceSelect extends AbstractSearchPlacesEvent {}
+}

--- a/code/src/OSFramework/OSCallback/SearchPlaces.ts
+++ b/code/src/OSFramework/OSCallback/SearchPlaces.ts
@@ -1,0 +1,17 @@
+/**
+ * Namespace that contains the callbacks signatures to be passed in the SearchPlaces events.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Callbacks.SearchPlaces {
+    /**
+     * This is the callback signature for events triggered by the SearchPlaces.
+     * @param {OSFramework.SearchPlaces.ISearchPlaces} searchPlacesObj object of the SearchPlaces which triggered the event
+     * @param {string} searchPlacesId which SearchPlaces triggered the event
+     */
+    export type Event = {
+        (
+            searchPlacesObj: OSFramework.SearchPlaces.ISearchPlaces,
+            searchPlacesId: string
+        ): void;
+    };
+}

--- a/code/src/PlacesAPI/SearchPlacesManager.Events.ts
+++ b/code/src/PlacesAPI/SearchPlacesManager.Events.ts
@@ -1,0 +1,141 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace PlacesAPI.SearchPlacesManager.Events {
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    const _pendingEvents: Map<
+        string,
+        {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            cb: any;
+            event: OSFramework.Event.SearchPlaces.SearchPlacesEventType;
+        }[]
+    > = new Map<
+        string,
+        {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            cb: any;
+            event: OSFramework.Event.SearchPlaces.SearchPlacesEventType;
+        }[]
+    >();
+
+    const _eventsToSearchPlacesId = new Map<string, string>(); //event.uniqueId -> searchPlaces.uniqueId
+
+    /**
+     * API method to check if there are pending events for a specific SearchPlaces
+     *
+     * @export
+     * @param {string} searchPlaces SearchPlaces that is ready for events
+     */
+    export function CheckPendingEvents(
+        searchPlaces: OSFramework.SearchPlaces.ISearchPlaces
+    ): void {
+        // For each key of the pendingEvents check if the searchPlaces has the key as a widgetId or uniqueId and add the new handler
+        for (const key of _pendingEvents.keys()) {
+            if (searchPlaces.equalsToID(key)) {
+                _pendingEvents.get(key).forEach((obj) => {
+                    searchPlaces.searchPlacesEvents.addHandler(
+                        obj.event,
+                        obj.cb
+                    );
+                });
+                // Make sure to delete the entry from the pendingEvents
+                _pendingEvents.delete(key);
+            }
+        }
+    }
+
+    /**
+     * Returns the SearchPlacesId based on the eventUniqueId
+     * @param eventUniqueId UniqueId of our Event
+     * @param lookUpDOM Search in DOM by the parent SearchPlaces
+     */
+    export function GetSearchPlacesByEventUniqueId(
+        eventUniqueId: string,
+        lookUpDOM = true
+    ): string {
+        //Try to find in DOM only if not present on SearchPlaces
+        if (lookUpDOM && !_eventsToSearchPlacesId.has(eventUniqueId)) {
+            const eventElement =
+                OSFramework.Helper.GetElementByUniqueId(eventUniqueId);
+            const searchPlacesId =
+                OSFramework.Helper.GetClosestSearchPlacesId(eventElement);
+            const searchPlaces = GetSearchPlacesById(searchPlacesId);
+
+            if (searchPlaces) {
+                _eventsToSearchPlacesId.set(eventUniqueId, searchPlacesId);
+            }
+        }
+
+        return _eventsToSearchPlacesId.get(eventUniqueId);
+    }
+
+    /**
+     * API method to subscribe to events of a specific SearchPlaces
+     *
+     * @export
+     * @param {string} searchPlacesId SearchPlaces where the event will be attached
+     * @param {OSFramework.Event.SearchPlaces.SearchPlacesEventType} eventName name fo the event to be attached
+     * @param {SearchPlacesAPI.Callbacks.SearchPlaces.Event} callback callback to be invoked when the event occurs
+     */
+    export function Subscribe(
+        searchPlacesId: string,
+        eventName: OSFramework.Event.SearchPlaces.SearchPlacesEventType,
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+        callback: OSFramework.Callbacks.SearchPlaces.Event
+    ): void {
+        // Let's make sure that if the SearchPlaces doesn't exist, we don't throw and exception but instead add the handler to the pendingEvents
+        const searchPlaces = GetSearchPlacesById(searchPlacesId, false);
+        if (searchPlaces === undefined) {
+            if (_pendingEvents.has(searchPlacesId)) {
+                _pendingEvents.get(searchPlacesId).push({
+                    event: eventName,
+                    cb: callback
+                });
+            } else {
+                _pendingEvents.set(searchPlacesId, [
+                    {
+                        event: eventName,
+                        cb: callback
+                    }
+                ]);
+            }
+        } else {
+            searchPlaces.searchPlacesEvents.addHandler(eventName, callback);
+        }
+    }
+
+    /**
+     * API method to unsubscribe an event from a specific SearchPlaces
+     *
+     * @export
+     * @param {string} eventUniqueId Event Id that will get removed
+     * @param {OSFramework.Event.SearchPlaces.SearchPlacesEventType} eventName name of the event to be removed
+     * @param {SearchPlacesAPI.Callbacks.SearchPlaces.Event} callback callback that will be removed
+     */
+    export function Unsubscribe(
+        eventUniqueId: string,
+        eventName: OSFramework.Event.SearchPlaces.SearchPlacesEventType,
+        // eslint-disable-next-line
+        callback: OSFramework.Callbacks.SearchPlaces.Event
+    ): void {
+        const searchPlacesId = GetSearchPlacesByEventUniqueId(eventUniqueId);
+        const searchPlaces = GetSearchPlacesById(searchPlacesId, false);
+
+        if (searchPlaces !== undefined) {
+            searchPlaces.searchPlacesEvents.removeHandler(eventName, callback);
+        } else {
+            if (_pendingEvents.has(searchPlacesId)) {
+                const index = _pendingEvents
+                    .get(searchPlacesId)
+                    .findIndex((element) => {
+                        return (
+                            element.event === eventName &&
+                            element.cb === callback
+                        );
+                    });
+                if (index !== -1) {
+                    _pendingEvents.get(searchPlacesId).splice(index, 1);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is for the part 4 of RGRIDT-996: [Maps] SearchPlace (search autocomplete) which includes:
- SearchPlaces events: onPlaceSelect and onError (also prepared for onInitialize)

### What was happening
* As an OS developer, I want to provide address search with autocomplete to my end-users so that they are able to find the address or location they are looking for.

### What was done
* Added all the logic related to the SearchPlaces events

### Tests
Test case | Test steps
-- | --
Platform “if” false SearchPlaces | 1.Toggle Off the "Show/Hide" on the SearchPlaces<br>**Expected: The SearchPlaces should not appear on the page**
Platform “if” true SearchPlaces | 1.Toggle On the "Show/Hide" on the SearchPlaces<br>**Expected: The SearchPlaces should appear on the page**
Search prediction | 1.Toggle On the "Show/Hide" on the SearchPlaces<br>2. Search for "Lisb"<br>**Expected: The SearchPlaces should present a dropdown with the option "Lisbon"**
No input Error | 1.Toggle On the "Show/Hide" on the SearchPlaces<br>**Expected: A feedback message with the error "SearchPlaces must have an input. Try to add one inside the placeholder of the Block."**
Wrong SearchType on SearchPlaces | 1.Toggle On the "Show/Hide" on the SearchPlaces<br>2. Search for "Centro comercial vas"<br>**Expected: The SearchPlaces should not present a dropdown with the option "Centro Vasco da Gama"**
SearchType on SearchPlaces | 1.Toggle On the "Show/Hide" on the SearchPlaces<br>2. Change the SearchType dropdown to "Establishments"<br>3. Search for "Centro comercial vas"<br>**Expected: The SearchPlaces should present a dropdown with the option "Centro Vasco da Gama"**
Wrong SearchArea on SearchPlaces | 1.Toggle On the "Show/Hide" on the SearchPlaces<br>2. Search for "Centro comercial Col"<br>**Expected: The SearchPlaces should not present a dropdown with the option "Centro Comercial Colombo"**
SearchArea on SearchPlaces | 1.Toggle On the "Show/Hide" on the SearchPlaces<br>2. Change the SearchType dropdown to "Establishments"<br>3. Change Bounds of South and West to "Cascais, PT"<br>4. Search for "Centro comercial Col"<br>**Expected: The SearchPlaces should present a dropdown with the option "Centro Comercial Colombo"**
Wrong Country on SearchPlaces | "1.Toggle On the ""Show/Hide"" on the SearchPlaces<br>2. Search for""Madr""<br>**Expected: The SearchPlaces should not present a dropdown with the option ""Madrid"""**
Country on SearchPlaces | 1.Toggle On the "Show/Hide" on the SearchPlaces<br>2. Change Countries to "ES"<br>3. Search for"Madr"<br>**Expected: The SearchPlaces should present a dropdown with the option "Lisbon"**
EventHandling on SearchPlaces | 1. Toggle On the "Show/Hide" on the SearchPlaces<br>2. Search for "Lisb"<br>3. Click on the option "Lisbon"<br>**Expected: A feedback message should appear with the text "38.7222524,-9.1393366. Name: Lisbon. Address:Lisbon, Portugal"**


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes) **- RGRIDT-996**
* [x] requires new sample page in OutSystems (if so, provide a module with changes) - **TBD**

