### PR TITLE
RGRIDT-1088: [Bug] removeMarkers method needs map with features / markerClusterer (Sample Apps)

### DIFF
--- a/code/src/OSFramework/OSMap/AbstractMap.ts
+++ b/code/src/OSFramework/OSMap/AbstractMap.ts
@@ -280,6 +280,11 @@ namespace OSFramework.OSMap {
                 return;
             }
             this._markers.forEach((marker) => {
+                // Make sure the marker is removed from any existent cluster
+                // But first ensure that map.features exist as well as the features.markerClusterer
+                this.features &&
+                    this.features.markerClusterer &&
+                    this.features.markerClusterer.removeMarker(marker);
                 marker.dispose();
             });
 
@@ -377,7 +382,10 @@ namespace OSFramework.OSMap {
                 const marker = this._markers.get(markerId);
 
                 // Make sure the marker is removed from any existent cluster
-                this.features.markerClusterer?.removeMarker(marker);
+                // But first ensure that map.features exist as well as the features.markerClusterer
+                this.features &&
+                    this.features.markerClusterer &&
+                    this.features.markerClusterer.removeMarker(marker);
                 marker.dispose();
                 this._markers.delete(markerId);
                 this._markersSet.delete(marker);


### PR DESCRIPTION
This PR is for RGRIDT-1088: [Bug] removeMarkers method needs a map with features / markerClusterer (Sample Apps)

### What was happening
* When the Map was removing its markers before having the features built, an error was being thrown (on the console)

### What was done
* Adding validation to make sure the features of the Map exist before using the markerClusterer feature.

### Screenshots
![image](https://user-images.githubusercontent.com/6432232/143875262-99a8fda0-f9d2-4a40-a5ac-c4c4046b9b73.png)

### Checklist
* [x] tested locally
* [x] documented the code
* [ ] clean all warnings and errors of eslint - **NA**
* [ ] requires changes in OutSystems (if so, provide a module with changes) - **NA**
* [ ] requires new sample page in OutSystems (if so, provide a module with changes) - **NA**