### PR TITLE
RGRIDT-1025: [Maps] Leaflet Integration - Marker [LeafletMap and Google Maps events] Pt.3

### DIFF
--- a/code/src/GoogleProvider/Constants/Marker/Events.ts
+++ b/code/src/GoogleProvider/Constants/Marker/Events.ts
@@ -1,30 +1,30 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace GoogleProvider.Constants.Marker {
     /**
-     * Array of strings that define the available Provider Events
+     * Enum that defines the available Provider Events
      */
-    export const Events = [
-        'animation_changed',
-        'click',
-        'clickable_changed',
-        'contextmenu',
-        'cursor_changed',
-        'dblclick',
-        'drag',
-        'dragend',
-        'draggable_changed',
-        'dragstart',
-        'flat_changed',
-        'icon_changed',
-        'mousedown',
-        'mouseout',
-        'mouseover',
-        'mouseup',
-        'position_changed',
-        'rightclick',
-        'shape_changed',
-        'title_changed',
-        'visible_changed',
-        'zindex_changed'
-    ];
+    export enum ProviderEventNames {
+        animation_changed = 'animation_changed',
+        click = 'click',
+        clickable_changed = 'clickable_changed',
+        contextmenu = 'contextmenu',
+        cursor_changed = 'cursor_changed',
+        dblclick = 'dblclick',
+        drag = 'drag',
+        dragend = 'dragend',
+        draggable_changed = 'draggable_changed',
+        dragstart = 'dragstart',
+        flat_changed = 'flat_changed',
+        icon_changed = 'icon_changed',
+        mousedown = 'mousedown',
+        mouseout = 'mouseout',
+        mouseover = 'mouseover',
+        mouseup = 'mouseup',
+        position_changed = 'position_changed',
+        rightclick = 'rightclick',
+        shape_changed = 'shape_changed',
+        title_changed = 'title_changed',
+        visible_changed = 'visible_changed',
+        zindex_changed = 'zindex_changed'
+    }
 }

--- a/code/src/LeafletProvider/Constants/Marker/Events.ts
+++ b/code/src/LeafletProvider/Constants/Marker/Events.ts
@@ -1,0 +1,19 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace LeafletProvider.Constants.Marker {
+    /**
+     * Enum that defines the available Provider Events
+     */
+    export enum ProviderEventNames {
+        click = 'click',
+        contextmenu = 'contextmenu',
+        rightclick = 'contextmenu',
+        dblclick = 'dblclick',
+        drag = 'drag',
+        dragend = 'dragend',
+        dragstart = 'dragstart',
+        mousedown = 'mousedown',
+        mouseout = 'mouseout',
+        mouseover = 'mouseover',
+        mouseup = 'mouseup'
+    }
+}


### PR DESCRIPTION
This PR is for RGRIDT-1025: [Maps] Leaflet Integration - Marker:
- Leaflet marker events
- Google Maps marker events

### What was happening
* There was a need to add a Leaflet Integration (parity feature to the existing Google Maps Map feature)
* The Marker block shows markers when using "Provider" = Leaflet. 

### What was done
* Added all the provider events that can be used by both providers for the marker block

### Screenshots
![previewProviders](https://user-images.githubusercontent.com/6432232/142608893-88a79179-fa26-4dd5-bf7c-bfe2ca806dc9.gif)

### Checklist
* [ ] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes) - **RGRIDT-1018**
* [ ] requires new sample page in OutSystems (if so, provide a module with changes) - **TBD**