### PR TITLE
RGRIDT-1025: Fixing bug related to OnClick on marker for leaflet

### DIFF
--- a/code/src/LeafletProvider/Marker/Marker.ts
+++ b/code/src/LeafletProvider/Marker/Marker.ts
@@ -152,11 +152,24 @@ namespace LeafletProvider.Marker {
                     OSFramework.Event.Marker.MarkerEventType.OnClick
                 )
             ) {
-                this._provider.addEventListener('click', () => {
-                    this.markerEvents.trigger(
-                        OSFramework.Event.Marker.MarkerEventType.OnClick
-                    );
-                });
+                this._provider.addEventListener(
+                    'click',
+                    (e?: L.LeafletMouseEvent) => {
+                        const coordinates =
+                            new OSFramework.OSStructures.OSMap.OSCoordinates(
+                                e.latlng.lat,
+                                e.latlng.lng
+                            );
+                        this.markerEvents.trigger(
+                            // EventType
+                            OSFramework.Event.Marker.MarkerEventType.OnClick,
+                            // EventName
+                            OSFramework.Event.Marker.MarkerEventType.OnClick,
+                            // Coords
+                            JSON.stringify(coordinates)
+                        );
+                    }
+                );
             }
 
             // Any events that got added to the markerEvents via the API Subscribe method will have to be taken care here

--- a/code/styles/Map.css
+++ b/code/styles/Map.css
@@ -39,7 +39,7 @@ html[data-uieditorversion^="1"] .map-wrapper .staticMap-image {
 }  
 
 .map-container {   
-    -servicestudio-background: var(--map-container-image);
+    -servicestudio-background: var(--map-container-image-google);
     -servicestudio-background-repeat: no-repeat;
     -servicestudio-background-size: cover;
     -servicestudio-display: table;


### PR DESCRIPTION
This PR is for RGRIDT-1025: Fixing bug related to OnClick on marker for leaflet

### What was happening
* Related to RGRIDT-1049, there was a bug with the leaflet marker onclick event accelarator

### What was done
* Added the coordinates of the clicked marker

### Test Steps
1. Click on Marker Boston (for Leaflet Map)
**Expected:  You clicked on the marker with id: MarkerLeaflet(42.3517926,-71.0467845).**

### Checklist
* [x] tested locally
* [ ] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

