### PR TITLE
RGRIDT-1032: [Maps] Leaflet Integration - Shapes [Shape Factory + buildShapes enablement - part 2]

### DIFF
--- a/code/src/LeafletProvider/OSMap/OSMap.ts
+++ b/code/src/LeafletProvider/OSMap/OSMap.ts
@@ -178,6 +178,7 @@ namespace LeafletProvider.OSMap {
             );
             this.buildFeatures();
             this._buildMarkers();
+            this._buildShapes();
             this.finishBuild();
 
             // Make sure to change the center after the conversion of the location to coordinates

--- a/code/src/MapAPI/ShapeManager.ts
+++ b/code/src/MapAPI/ShapeManager.ts
@@ -40,7 +40,7 @@ namespace MapAPI.ShapeManager {
     ): OSFramework.Shape.IShape {
         const map = GetMapByShapeId(shapeId);
         if (!map.hasShape(shapeId)) {
-            const _shape = GoogleProvider.Shape.ShapeFactory.MakeShape(
+            const _shape = OSFramework.Shape.ShapeFactory.MakeShape(
                 map,
                 shapeId,
                 shapeType,

--- a/code/src/OSFramework/Shape/Factory.ts
+++ b/code/src/OSFramework/Shape/Factory.ts
@@ -1,0 +1,31 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Shape {
+    export namespace ShapeFactory {
+        export function MakeShape(
+            map: OSMap.IMap,
+            shapeId: string,
+            type: Enum.ShapeType,
+            configs: JSON
+        ): Shape.IShape {
+            switch (map.providerType) {
+                case Enum.ProviderType.Google:
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    return GoogleProvider.Shape.ShapeFactory.MakeShape(
+                        map,
+                        shapeId,
+                        type,
+                        configs as JSON
+                    );
+                case Enum.ProviderType.Leaflet:
+                    return LeafletProvider.Shape.ShapeFactory.MakeShape(
+                        map,
+                        shapeId,
+                        type,
+                        configs as JSON
+                    );
+                default:
+                    throw `There is no factory for the Shape using the provider ${map.providerType}`;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is for RGRIDT-1032: [Maps] Leaflet Integration - Shapes [Shape Factory + buildShapes enablement - part 2]

### What was happening
* Leaflet Integration (parity feature to the existing Google Maps Shapes features).

### What was done
* Added Shape Factory which will make sure to follow the correct provider for the shape factory (leaflet or google maps)
* Lint clean up
* Enabled the _buildShapes method on the OSMap.ts
* ... (continues on part 3)

### Checklist
* [ ] tested locally
* [x] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
