### PR TITLE
RGRIDT-1032: [Maps] Leaflet Integration - Shapes [Shape implementation + logic - part 3]

### DIFF
--- a/code/src/LeafletProvider/Shape/AbstractPolyshape.ts
+++ b/code/src/LeafletProvider/Shape/AbstractPolyshape.ts
@@ -1,0 +1,157 @@
+/// <reference path="AbstractProviderShape.ts" />
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace LeafletProvider.Shape {
+    export abstract class AbstractPolyshape<
+            T extends OSFramework.Configuration.IConfigurationShape,
+            W extends L.Polygon | L.Polyline
+        >
+        extends AbstractProviderShape<T, W>
+        implements OSFramework.Shape.IShapePolyshape
+    {
+        public get providerEventsList(): Array<string> {
+            return Constants.Shape.ProviderPolyshapeEvents;
+        }
+
+        public get providerPath(): L.LatLng[] {
+            const path = this.providerObjectPath;
+            if (path === undefined) {
+                OSFramework.Helper.ThrowError(
+                    this.map,
+                    OSFramework.Enum.ErrorCodes.API_FailedGettingShapePath
+                );
+                return [];
+            }
+
+            return path as L.LatLng[];
+        }
+
+        /** Builds the path from a set of multiple locations (string format) */
+        private _buildPath(
+            loc: string
+        ): Promise<Array<OSFramework.OSStructures.OSMap.Coordinates>> {
+            // If the Shape doesn't have the minimum valid address/coordinates, then throw an error
+            if (this._validateLocations(loc)) {
+                const _locations = JSON.parse(loc);
+                // Let's return a promise that will be resolved or rejected according to the result
+                return new Promise((resolve, reject) => {
+                    const shapePath: Map<
+                        number,
+                        OSFramework.OSStructures.OSMap.Coordinates
+                    > = new Map();
+
+                    // As soon as one location from the locations input is not valid:
+                    // Is not a string / Is empty
+                    // Throw an error for invalid Locations
+                    _locations.every((location: string, index: number) => {
+                        // Make sure the current location from the array of locations is not empty
+                        if (OSFramework.Helper.IsEmptyString(location)) {
+                            OSFramework.Helper.ThrowError(
+                                this.map,
+                                this.invalidShapeLocationErrorCode
+                            );
+                            return false;
+                        }
+
+                        Helper.Conversions.ValidateCoordinates(location)
+                            .then((response) => {
+                                shapePath.set(index, {
+                                    lat: response.lat,
+                                    lng: response.lng
+                                });
+                                if (shapePath.size === _locations.length) {
+                                    resolve(
+                                        // This method is async
+                                        // We need to make sure the path is sorted correctly when all coordinates are retrieved
+                                        Array.from(shapePath.keys())
+                                            .sort((a, b) => a - b)
+                                            .map((key) => shapePath.get(key))
+                                    );
+                                }
+                            })
+                            .catch((e) => reject(e));
+                        return true;
+                    });
+                });
+            }
+        }
+
+        /** Set the provider path from an array of coordinates */
+        private _setProviderPath(
+            path: Array<OSFramework.OSStructures.OSMap.Coordinates>
+        ): void {
+            this._provider.setLatLngs(path);
+        }
+
+        /** Validates if the locations are accepted for the Shape's path considering the minimum valid address/coordinates */
+        private _validateLocations(loc: string): boolean {
+            if (
+                OSFramework.Helper.IsEmptyString(loc) ||
+                JSON.parse(loc).length < this.minPath
+            ) {
+                OSFramework.Helper.ThrowError(
+                    this.map,
+                    this.invalidShapeLocationErrorCode
+                );
+                return false;
+            }
+            return true;
+        }
+
+        public build(): void {
+            super.build();
+
+            // Before creating the provider we need to first set the shape path
+            const shapePath = this._buildPath(this.config.locations);
+            this.buildProvider(shapePath);
+        }
+
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+        public changeProperty(propertyName: string, value: any): void {
+            const propValue = OSFramework.Enum.OS_Config_Shape[propertyName];
+            super.changeProperty(propertyName, value);
+            if (this.isReady) {
+                switch (propValue) {
+                    case OSFramework.Enum.OS_Config_Shape.locations:
+                        // eslint-disable-next-line no-case-declarations
+                        const shapePath = this._buildPath(value);
+                        // If path is undefined (should be a promise) -> don't create the shape
+                        if (shapePath !== undefined) {
+                            shapePath
+                                .then((path) => {
+                                    this._setProviderPath(path);
+                                })
+                                .catch((error) => {
+                                    OSFramework.Helper.ThrowError(
+                                        this.map,
+                                        OSFramework.Enum.ErrorCodes
+                                            .LIB_FailedGeocodingShapeLocations,
+                                        error
+                                    );
+                                });
+                        }
+                        return;
+                    case OSFramework.Enum.OS_Config_Shape.fillColor:
+                        this.provider.setStyle({ fillColor: value });
+                        return;
+                    case OSFramework.Enum.OS_Config_Shape.fillOpacity:
+                        this.provider.setStyle({ fillOpacity: value });
+                        return;
+                }
+            }
+        }
+
+        protected abstract createProvider(
+            path: Array<OSFramework.OSStructures.OSMap.Coordinates>
+        ): W;
+
+        /** Get the provider path */
+        protected abstract get providerObjectPath():
+            | L.LatLng
+            | L.LatLng[]
+            | L.LatLng[][]
+            | L.LatLng[][][];
+
+        public abstract get shapeTag(): string;
+    }
+}

--- a/code/src/LeafletProvider/Shape/Circle.ts
+++ b/code/src/LeafletProvider/Shape/Circle.ts
@@ -1,0 +1,143 @@
+/// <reference path="AbstractProviderShape.ts" />
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace LeafletProvider.Shape {
+    export class Circle
+        extends AbstractProviderShape<
+            Configuration.Shape.CircleShapeConfig,
+            L.Circle
+        >
+        implements OSFramework.Shape.IShapeCircle
+    {
+        constructor(
+            map: OSFramework.OSMap.IMap,
+            shapeId: string,
+            type: OSFramework.Enum.ShapeType,
+            configs: JSON
+        ) {
+            super(
+                map,
+                shapeId,
+                type,
+                new Configuration.Shape.CircleShapeConfig(configs)
+            );
+        }
+
+        protected get invalidShapeLocationErrorCode(): OSFramework.Enum.ErrorCodes {
+            return OSFramework.Enum.ErrorCodes.CFG_InvalidCircleShapeCenter;
+        }
+
+        protected get providerObjectListener(): L.Circle {
+            return this.provider;
+        }
+
+        public get providerCenter(): OSFramework.OSStructures.OSMap.Coordinates {
+            const center = this.provider.getLatLng();
+            if (center === undefined) {
+                OSFramework.Helper.ThrowError(
+                    this.map,
+                    OSFramework.Enum.ErrorCodes.API_FailedGettingShapeCenter
+                );
+            }
+
+            return center;
+        }
+
+        public get providerEventsList(): Array<string> {
+            return Constants.Shape.ProviderCircleEvents;
+        }
+
+        public get providerRadius(): number {
+            const center = this.provider.getRadius();
+            if (center === undefined) {
+                OSFramework.Helper.ThrowError(
+                    this.map,
+                    OSFramework.Enum.ErrorCodes.API_FailedGettingShapeRadius
+                );
+            }
+
+            return center;
+        }
+
+        public get shapeTag(): string {
+            return OSFramework.Helper.Constants.shapeCircleTag;
+        }
+
+        private _buildCenter(
+            location: string
+        ): Promise<OSFramework.OSStructures.OSMap.Coordinates> {
+            // If the Shape doesn't have the minimum valid address/coordinates, then throw an error
+            if (OSFramework.Helper.IsEmptyString(location)) {
+                OSFramework.Helper.ThrowError(
+                    this.map,
+                    this.invalidShapeLocationErrorCode
+                );
+                return;
+            }
+
+            return new Promise((resolve, reject) => {
+                Helper.Conversions.ValidateCoordinates(location)
+                    .then((response) => {
+                        const coordinates = {
+                            lat: response.lat,
+                            lng: response.lng
+                        };
+                        resolve(coordinates);
+                    })
+                    .catch((e) => reject(e));
+            });
+        }
+
+        protected createProvider(
+            center: OSFramework.OSStructures.OSMap.Coordinates
+        ): L.Circle {
+            return new L.Circle(center, this.getProviderConfig());
+        }
+
+        public build(): void {
+            super.build();
+            // First build center coordinates based on the location
+            // Then, create the provider (Leaflet Shape)
+            const shapeCenter = this._buildCenter(this.config.center);
+            super.buildProvider(shapeCenter);
+        }
+
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+        public changeProperty(propertyName: string, value: any): void {
+            const propValue = OSFramework.Enum.OS_Config_Shape[propertyName];
+            super.changeProperty(propertyName, value);
+            if (this.isReady) {
+                switch (propValue) {
+                    case OSFramework.Enum.OS_Config_Shape.center:
+                        // eslint-disable-next-line no-case-declarations
+                        const shapeCenter = this._buildCenter(value);
+                        // If path is undefined (should be a promise) -> don't create the shape
+                        if (shapeCenter !== undefined) {
+                            shapeCenter
+                                .then((center) => {
+                                    this.provider.setLatLng(center);
+                                })
+                                .catch((error) => {
+                                    OSFramework.Helper.ThrowError(
+                                        this.map,
+                                        OSFramework.Enum.ErrorCodes
+                                            .LIB_FailedGeocodingShapeLocations,
+                                        error
+                                    );
+                                });
+                        }
+                        return;
+                    case OSFramework.Enum.OS_Config_Shape.radius:
+                        this.provider.setRadius(value);
+                        return;
+                    case OSFramework.Enum.OS_Config_Shape.fillColor:
+                        this.provider.setStyle({ fillColor: value });
+                        return;
+                    case OSFramework.Enum.OS_Config_Shape.fillOpacity:
+                        this.provider.setStyle({ fillOpacity: value });
+                        return;
+                }
+            }
+        }
+    }
+}

--- a/code/src/LeafletProvider/Shape/Factory.ts
+++ b/code/src/LeafletProvider/Shape/Factory.ts
@@ -1,0 +1,24 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace LeafletProvider.Shape {
+    export namespace ShapeFactory {
+        export function MakeShape(
+            map: OSFramework.OSMap.IMap,
+            shapeId: string,
+            type: OSFramework.Enum.ShapeType,
+            configs: JSON
+        ): OSFramework.Shape.IShape {
+            switch (type) {
+                case OSFramework.Enum.ShapeType.Polygon:
+                    return new Polygon(map, shapeId, type, configs);
+                case OSFramework.Enum.ShapeType.Polyline:
+                    return new Polyline(map, shapeId, type, configs);
+                case OSFramework.Enum.ShapeType.Circle:
+                    return new Circle(map, shapeId, type, configs);
+                case OSFramework.Enum.ShapeType.Rectangle:
+                    return new Rectangle(map, shapeId, type, configs);
+                default:
+                    throw `There is no factory for this type of Shape (${type})`;
+            }
+        }
+    }
+}

--- a/code/src/LeafletProvider/Shape/Polygon.ts
+++ b/code/src/LeafletProvider/Shape/Polygon.ts
@@ -1,0 +1,46 @@
+/// <reference path="AbstractPolyshape.ts" />
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace LeafletProvider.Shape {
+    export class Polygon extends AbstractPolyshape<
+        Configuration.Shape.FilledShapeConfig,
+        L.Polygon
+    > {
+        constructor(
+            map: OSFramework.OSMap.IMap,
+            shapeId: string,
+            type: OSFramework.Enum.ShapeType,
+            configs: JSON
+        ) {
+            super(
+                map,
+                shapeId,
+                type,
+                new Configuration.Shape.FilledShapeConfig(configs)
+            );
+        }
+
+        protected get invalidShapeLocationErrorCode(): OSFramework.Enum.ErrorCodes {
+            return OSFramework.Enum.ErrorCodes.CFG_InvalidPolygonShapeLocations;
+        }
+
+        protected get providerObjectPath():
+            | L.LatLng
+            | L.LatLng[]
+            | L.LatLng[][]
+            | L.LatLng[][][] {
+            // We need to get the first position of the Array because here the latLngs are inside an
+            return this.provider.getLatLngs()[0];
+        }
+
+        public get shapeTag(): string {
+            return OSFramework.Helper.Constants.shapePolygonTag;
+        }
+
+        protected createProvider(
+            path: Array<OSFramework.OSStructures.OSMap.Coordinates>
+        ): L.Polygon {
+            return new L.Polygon(path, this.getProviderConfig());
+        }
+    }
+}

--- a/code/src/LeafletProvider/Shape/Polyline.ts
+++ b/code/src/LeafletProvider/Shape/Polyline.ts
@@ -1,0 +1,45 @@
+/// <reference path="AbstractPolyshape.ts" />
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace LeafletProvider.Shape {
+    export class Polyline extends AbstractPolyshape<
+        Configuration.Shape.BasicShapeConfig,
+        L.Polyline
+    > {
+        constructor(
+            map: OSFramework.OSMap.IMap,
+            shapeId: string,
+            type: OSFramework.Enum.ShapeType,
+            configs: JSON
+        ) {
+            super(
+                map,
+                shapeId,
+                type,
+                new Configuration.Shape.BasicShapeConfig(configs)
+            );
+        }
+
+        protected get invalidShapeLocationErrorCode(): OSFramework.Enum.ErrorCodes {
+            return OSFramework.Enum.ErrorCodes
+                .CFG_InvalidPolylineShapeLocations;
+        }
+
+        protected get providerObjectPath():
+            | L.LatLng[]
+            | L.LatLng[][]
+            | L.LatLng[][][] {
+            return this.provider.getLatLngs();
+        }
+
+        public get shapeTag(): string {
+            return OSFramework.Helper.Constants.shapePolylineTag;
+        }
+
+        protected createProvider(
+            path: Array<OSFramework.OSStructures.OSMap.Coordinates>
+        ): L.Polyline {
+            return new L.Polyline(path, this.getProviderConfig());
+        }
+    }
+}

--- a/code/src/LeafletProvider/Shape/Rectangle.ts
+++ b/code/src/LeafletProvider/Shape/Rectangle.ts
@@ -1,0 +1,180 @@
+/// <reference path="AbstractProviderShape.ts" />
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace LeafletProvider.Shape {
+    export class Rectangle
+        extends AbstractProviderShape<
+            Configuration.Shape.RectangleShapeConfig,
+            L.Rectangle
+        >
+        implements OSFramework.Shape.IShapeRectangle
+    {
+        constructor(
+            map: OSFramework.OSMap.IMap,
+            shapeId: string,
+            type: OSFramework.Enum.ShapeType,
+            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+            configs: any
+        ) {
+            super(
+                map,
+                shapeId,
+                type,
+                new Configuration.Shape.RectangleShapeConfig(configs)
+            );
+        }
+
+        protected get invalidShapeLocationErrorCode(): OSFramework.Enum.ErrorCodes {
+            return OSFramework.Enum.ErrorCodes.CFG_InvalidRectangleShapeBounds;
+        }
+
+        public get bounds(): OSFramework.OSStructures.OSMap.Bounds {
+            const providerBounds: L.LatLngBounds = this.provider.getBounds();
+            const bounds = new OSFramework.OSStructures.OSMap.Bounds();
+
+            // Map providerBounds into OSFramework bounds structure
+            bounds.east = providerBounds.getNorthEast().lng;
+            bounds.north = providerBounds.getNorthEast().lat;
+            bounds.west = providerBounds.getSouthWest().lng;
+            bounds.south = providerBounds.getSouthWest().lat;
+            return bounds;
+        }
+
+        public get providerEventsList(): Array<string> {
+            return Constants.Shape.ProviderRectangleEvents;
+        }
+
+        public get shapeTag(): string {
+            return OSFramework.Helper.Constants.shapeRectangleTag;
+        }
+
+        // From the structure Bounds (north, south, east, weast) we need to convert the locations into the correct format of bounds
+        // For instance (north: string -> north: number)
+        private _buildBounds(
+            boundsString: string
+        ): Promise<OSFramework.OSStructures.OSMap.Bounds> {
+            const bounds: OSFramework.OSStructures.OSMap.BoundsString =
+                JSON.parse(boundsString);
+            // If the Shape doesn't have the minimum valid address/coordinates, then throw an error
+            if (OSFramework.Helper.HasAnyEmptyBound(bounds)) {
+                OSFramework.Helper.ThrowError(
+                    this.map,
+                    this.invalidShapeLocationErrorCode
+                );
+                return;
+            }
+
+            // make sure the provided bounds (string) have the correct format
+            // this method will then return a promise that will be resolved on the _buildProvider
+            return this._convertStringToBounds(bounds);
+        }
+
+        /**
+         * This method will help converting the bounds (string) into the respective coordinates that will be used on the bounds
+         * It returns a promise because bounds will get converted into coordinates
+         * The method resposible for this conversion (Helper.Conversions.ValidateCoordinates) also returns a Promise
+         * This Promise will only get resolved after the provider gets built (asynchronously)
+         */
+        private _convertStringToBounds(
+            bounds: OSFramework.OSStructures.OSMap.BoundsString
+        ): Promise<OSFramework.OSStructures.OSMap.Bounds> {
+            const cardinalDirections = ['north', 'south', 'east', 'west'];
+            return new Promise((resolve, reject) => {
+                let boundsLength = 0;
+                const newBounds = new OSFramework.OSStructures.OSMap.Bounds();
+                cardinalDirections.forEach((cd) => {
+                    // Regex that validates if string is a coordinate (latitude or longitude)
+                    const regexValidator = /^-{0,1}\d*\.{0,1}\d*$/;
+                    if (regexValidator.test(bounds[cd])) {
+                        boundsLength++;
+                        newBounds[cd] = parseFloat(bounds[cd]);
+                        if (boundsLength === 4) {
+                            resolve(newBounds);
+                        }
+                    } else {
+                        Helper.Conversions.ValidateCoordinates(bounds[cd])
+                            .then((response) => {
+                                boundsLength++;
+                                switch (cd) {
+                                    case 'north':
+                                    case 'south':
+                                        newBounds[cd] = response.lat;
+                                        break;
+                                    case 'east':
+                                    case 'west':
+                                    default:
+                                        newBounds[cd] = response.lng;
+                                        break;
+                                }
+                                if (boundsLength === 4) {
+                                    resolve(newBounds);
+                                }
+                            })
+                            .catch((e) => reject(e));
+                    }
+                });
+            });
+        }
+
+        protected createProvider(
+            bounds: OSFramework.OSStructures.OSMap.Bounds
+        ): L.Rectangle {
+            const providerBounds: L.LatLngBoundsExpression = [
+                [bounds.south, bounds.west],
+                [bounds.north, bounds.east]
+            ];
+            return new L.Rectangle(providerBounds, {
+                ...this.getProviderConfig()
+            });
+        }
+
+        public build(): void {
+            super.build();
+
+            // First build the bounds with the coordinates
+            // Then, create the provider (Leaflet Shape)
+            const bounds = this._buildBounds(this.config.bounds);
+            super.buildProvider(bounds);
+        }
+
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+        public changeProperty(propertyName: string, value: any): void {
+            const propValue = OSFramework.Enum.OS_Config_Shape[propertyName];
+            super.changeProperty(propertyName, value);
+            if (this.isReady) {
+                switch (propValue) {
+                    case OSFramework.Enum.OS_Config_Shape.fillColor:
+                        this.provider.setStyle({ fillColor: value });
+                        return;
+                    case OSFramework.Enum.OS_Config_Shape.fillOpacity:
+                        this.provider.setStyle({ fillOpacity: value });
+                        return;
+                    case OSFramework.Enum.OS_Config_Shape.bounds:
+                        // eslint-disable-next-line no-case-declarations
+                        const shapeBounds = this._buildBounds(value);
+                        // If path is undefined (should be a promise) -> don't create the shape
+                        if (shapeBounds !== undefined) {
+                            shapeBounds
+                                .then((bounds) => {
+                                    const providerBounds: L.LatLngBoundsExpression =
+                                        [
+                                            [bounds.south, bounds.west],
+                                            [bounds.north, bounds.east]
+                                        ];
+                                    this.provider.setBounds(providerBounds);
+                                })
+                                .catch((error) => {
+                                    OSFramework.Helper.ThrowError(
+                                        this.map,
+                                        OSFramework.Enum.ErrorCodes
+                                            .LIB_FailedGeocodingShapeLocations,
+                                        error
+                                    );
+                                });
+                        }
+                        return;
+                }
+            }
+        }
+    }
+}

--- a/code/src/OSFramework/Shape/AbstractShape.ts
+++ b/code/src/OSFramework/Shape/AbstractShape.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.Shape {
     export abstract class AbstractShape<
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        W,
         T extends Configuration.IConfigurationShape
     > implements IShape
     {
@@ -12,7 +12,9 @@ namespace OSFramework.Shape {
         private _uniqueId: string;
         private _widgetId: string;
 
+        protected _addedEvents: Array<string>;
         protected _built: boolean;
+        protected _provider: W;
         protected _shapeEvents: Event.Shape.ShapeEventsManager;
 
         abstract hasEvents: boolean;
@@ -29,6 +31,7 @@ namespace OSFramework.Shape {
             this._built = false;
             this._shapeEvents = new Event.Shape.ShapeEventsManager(this);
             this._type = type;
+            this._addedEvents = [];
         }
 
         public get config(): T {
@@ -43,6 +46,9 @@ namespace OSFramework.Shape {
         /** Gets the minimum mandatory number of addresses/coordinates to create the path (depends on the shape) */
         public get minPath(): number {
             return Enum.ShapeMinPath[this._type];
+        }
+        public get provider(): W {
+            return this._provider;
         }
         public get shapeEvents(): Event.Shape.ShapeEventsManager {
             return this._shapeEvents;
@@ -117,8 +123,6 @@ namespace OSFramework.Shape {
         protected abstract get invalidShapeLocationErrorCode(): Enum.ErrorCodes;
 
         public abstract refreshProviderEvents(): void;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public abstract get provider(): any;
         public abstract get shapeProviderEvents(): Array<string>;
         public abstract get shapeTag(): string;
     }


### PR DESCRIPTION
This PR is for RGRIDT-1032: [Maps] Leaflet Integration - Shapes [Shape implementation + logic - part 3]

### What was happening
* Leaflet Integration (parity feature to the existing Google Maps Shapes features).

### What was done
* Created all the logic regarding shapes and abstracts (just like we have for the google provider):
  * AbstractShape (OSFramework) ← AbstractProviderShape (LeafletProvider) ←AbstractPolyshape ← **Polyline**
  * AbstractShape (OSFramework) ← AbstractProviderShape (LeafletProvider) ←AbstractPolyshape ← **Polygon**
  * AbstractShape (OSFramework) ← AbstractProviderShape (LeafletProvider) ← **Circle**
  * AbstractShape (OSFramework) ← AbstractProviderShape (LeafletProvider) ← **Rectangle**
* Lint clean up + GoogleProvider AbstractProviderShape fixed some variables and methods names
* Created the ShapeFactory on the LeafletProvider

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)
