### PR TITLE
RGRIDT-1027: [Maps] Leaflet Integration - Set directions [Part 1 - 1st Configs for Directions]

### DIFF
--- a/code/package.json
+++ b/code/package.json
@@ -21,6 +21,7 @@
     "@types/google.maps": "^3.46.0",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
+    "@types/leaflet-routing-machine": "^3.2.3",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^7.0.0",
     "eslint-plugin-prettier": "^3.4.1",

--- a/code/src/LeafletProvider/Constants/Directions/DirectionsProvider.ts
+++ b/code/src/LeafletProvider/Constants/Directions/DirectionsProvider.ts
@@ -1,0 +1,8 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace LeafletProvider.Constants.Directions {
+    export enum Provider {
+        OSRM = 'osrmv1',
+        MapBox = 'mapbox',
+        GraphHopper = 'graphHopper'
+    }
+}

--- a/code/src/LeafletProvider/Constants/Directions/TravelModes.ts
+++ b/code/src/LeafletProvider/Constants/Directions/TravelModes.ts
@@ -1,0 +1,48 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace LeafletProvider.Constants.Directions.OSRM {
+    /**
+     * Enum that defines the available OSRM TravelModes
+     */
+    export enum TravelModes {
+        DRIVING = 'car',
+        BICYCLING = 'bike',
+        WALKING = 'foot'
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace LeafletProvider.Constants.Directions.MapBox {
+    /**
+     * Enum that defines the available MapBox TravelModes
+     */
+    export enum TravelModes {
+        DRIVING = 'mapbox/driving',
+        BICYCLING = 'mapbox/cycling',
+        WALKING = 'mapbox/walking'
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace LeafletProvider.Constants.Directions.GraphHopper {
+    /**
+     * Enum that defines the available GraphHopper TravelModes
+     */
+    export enum TravelModes {
+        DRIVING = 'car',
+        BICYCLING = 'bike',
+        WALKING = 'foot'
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace LeafletProvider.Constants.Directions.TomTom {
+    /**
+     * Enum that defines the available TomTom TravelModes
+     */
+    export enum TravelModes {
+        DRIVING = 'car',
+        BICYCLING = 'bicycle',
+        WALKING = 'pedestrian',
+        TRANSIT = 'bus'
+    }
+}

--- a/code/src/LeafletProvider/Features/FeatureBuilder.ts
+++ b/code/src/LeafletProvider/Features/FeatureBuilder.ts
@@ -61,6 +61,10 @@ namespace LeafletProvider.Feature {
             this._features.center = this._makeItem(Center, center);
             return this;
         }
+        private _makeDirections(): FeatureBuilder {
+            this._features.directions = this._makeItem(Directions);
+            return this;
+        }
         private _makeInfoWindow(): FeatureBuilder {
             this._features.infoWindow = this._makeItem(InfoWindow);
             return this;
@@ -84,6 +88,7 @@ namespace LeafletProvider.Feature {
                 ._makeCenter(
                     config.center as OSFramework.OSStructures.OSMap.Coordinates
                 )
+                ._makeDirections()
                 ._makeOffset(config.offset)
                 ._makeInfoWindow();
 


### PR DESCRIPTION
This PR is for RGRIDT-1027: [Maps] Leaflet Integration - Set directions

### What was happening
* Leaflet Integration (parity feature to the existing Google Maps setDirections API)
* The wanted directions are shown on the Map when using "Provider" = Leaflet. 

### What was done
* Added the leaflet-routing-machine into the package.json (devDependencies)
* Added Enum for the Name of the service that provides the routing mechanisms
* Added Enum for the TravelModes that each provider allows using
* Enabled the _makeDirections on the FeatureBuilder for the LeafletMap

### Checklist
* [ ] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)