### PR TITLE
RGRIDT-1108: [Maps] Add warning message to map blocks still incompatible with Leaflet

### DIFF
--- a/code/src/MapAPI/DrawingToolsManager.ts
+++ b/code/src/MapAPI/DrawingToolsManager.ts
@@ -198,10 +198,13 @@ namespace MapAPI.DrawingToolsManager {
         configs: string
     ): OSFramework.DrawingTools.IDrawingTools {
         const map = GetMapByDrawingToolsId(drawingToolsId);
-        OSFramework.Helper.ValidateFeatureProvider(
-            map,
-            OSFramework.Enum.Feature.DrawingTools
-        );
+        if (
+            OSFramework.Helper.ValidateFeatureProvider(
+                map,
+                OSFramework.Enum.Feature.DrawingTools
+            ) === false
+        )
+            return;
         if (!map.drawingTools) {
             const _drawingTools =
                 GoogleProvider.DrawingTools.DrawingToolsFactory.MakeDrawingTools(

--- a/code/src/MapAPI/DrawingToolsManager.ts
+++ b/code/src/MapAPI/DrawingToolsManager.ts
@@ -203,8 +203,9 @@ namespace MapAPI.DrawingToolsManager {
                 map,
                 OSFramework.Enum.Feature.DrawingTools
             ) === false
-        )
+        ) {
             return;
+        }
         if (!map.drawingTools) {
             const _drawingTools =
                 GoogleProvider.DrawingTools.DrawingToolsFactory.MakeDrawingTools(

--- a/code/src/MapAPI/DrawingToolsManager.ts
+++ b/code/src/MapAPI/DrawingToolsManager.ts
@@ -193,12 +193,15 @@ namespace MapAPI.DrawingToolsManager {
      * @param {string} configs configurations for the DrawingTools in JSON format
      * @returns {*}  {DrawingTools.IDrawingTools} instance of the DrawingTools
      */
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     export function CreateDrawingTools(
         drawingToolsId: string,
         configs: string
     ): OSFramework.DrawingTools.IDrawingTools {
         const map = GetMapByDrawingToolsId(drawingToolsId);
+        OSFramework.Helper.ValidateFeatureProvider(
+            map,
+            OSFramework.Enum.Feature.DrawingTools
+        );
         if (!map.drawingTools) {
             const _drawingTools =
                 GoogleProvider.DrawingTools.DrawingToolsFactory.MakeDrawingTools(

--- a/code/src/MapAPI/FileLayerManager.Events.ts
+++ b/code/src/MapAPI/FileLayerManager.Events.ts
@@ -53,9 +53,25 @@ namespace MapAPI.FileLayerManager.Events {
         eventName: OSFramework.Event.FileLayer.FileLayersEventType,
         callback: OSFramework.Callbacks.FileLayer.Event
     ): void {
-        const fileLayer = GetFileLayerById(fileLayerId);
-        fileLayer.fileLayerEvents.addHandler(eventName, callback);
-        fileLayer.refreshProviderEvents();
+        const fileLayer = GetFileLayerById(fileLayerId, false);
+        if (fileLayer === undefined) {
+            if (_pendingEvents.has(fileLayerId)) {
+                _pendingEvents.get(fileLayerId).push({
+                    event: eventName,
+                    cb: callback
+                });
+            } else {
+                _pendingEvents.set(fileLayerId, [
+                    {
+                        event: eventName,
+                        cb: callback
+                    }
+                ]);
+            }
+        } else {
+            fileLayer.fileLayerEvents.addHandler(eventName, callback);
+            fileLayer.refreshProviderEvents();
+        }
     }
 
     /**

--- a/code/src/MapAPI/FileLayerManager.ts
+++ b/code/src/MapAPI/FileLayerManager.ts
@@ -79,8 +79,9 @@ namespace MapAPI.FileLayerManager {
                 map,
                 OSFramework.Enum.Feature.FileLayer
             ) === false
-        )
+        ) {
             return;
+        }
         if (!map.hasFileLayer(fileLayerId)) {
             const _fileLayer =
                 GoogleProvider.FileLayer.FileLayerFactory.MakeFileLayer(

--- a/code/src/MapAPI/FileLayerManager.ts
+++ b/code/src/MapAPI/FileLayerManager.ts
@@ -74,6 +74,10 @@ namespace MapAPI.FileLayerManager {
         configs: string
     ): OSFramework.FileLayer.IFileLayer {
         const map = GetMapByFileLayerId(fileLayerId);
+        OSFramework.Helper.ValidateFeatureProvider(
+            map,
+            OSFramework.Enum.Feature.FileLayer
+        );
         if (!map.hasFileLayer(fileLayerId)) {
             const _fileLayer =
                 GoogleProvider.FileLayer.FileLayerFactory.MakeFileLayer(
@@ -108,7 +112,7 @@ namespace MapAPI.FileLayerManager {
         );
 
         if (fileLayer === undefined && raiseError) {
-            throw new Error(`Marker id:${fileLayerId} not found`);
+            throw new Error(`FileLayer id:${fileLayerId} not found`);
         }
 
         return fileLayer;

--- a/code/src/MapAPI/FileLayerManager.ts
+++ b/code/src/MapAPI/FileLayerManager.ts
@@ -74,10 +74,13 @@ namespace MapAPI.FileLayerManager {
         configs: string
     ): OSFramework.FileLayer.IFileLayer {
         const map = GetMapByFileLayerId(fileLayerId);
-        OSFramework.Helper.ValidateFeatureProvider(
-            map,
-            OSFramework.Enum.Feature.FileLayer
-        );
+        if (
+            OSFramework.Helper.ValidateFeatureProvider(
+                map,
+                OSFramework.Enum.Feature.FileLayer
+            ) === false
+        )
+            return;
         if (!map.hasFileLayer(fileLayerId)) {
             const _fileLayer =
                 GoogleProvider.FileLayer.FileLayerFactory.MakeFileLayer(

--- a/code/src/MapAPI/HeatmapLayerManager.ts
+++ b/code/src/MapAPI/HeatmapLayerManager.ts
@@ -79,10 +79,13 @@ namespace MapAPI.HeatmapLayerManager {
         configs: string
     ): OSFramework.HeatmapLayer.IHeatmapLayer {
         const map = GetMapByHeatmapLayerId(heatmapLayerId);
-        OSFramework.Helper.ValidateFeatureProvider(
-            map,
-            OSFramework.Enum.Feature.HeatmapLayer
-        );
+        if (
+            OSFramework.Helper.ValidateFeatureProvider(
+                map,
+                OSFramework.Enum.Feature.HeatmapLayer
+            ) === false
+        )
+            return;
         if (!map.hasHeatmapLayer(heatmapLayerId)) {
             const _heatmapLayer =
                 GoogleProvider.HeatmapLayer.HeatmapLayerFactory.MakeHeatmapLayer(

--- a/code/src/MapAPI/HeatmapLayerManager.ts
+++ b/code/src/MapAPI/HeatmapLayerManager.ts
@@ -84,8 +84,9 @@ namespace MapAPI.HeatmapLayerManager {
                 map,
                 OSFramework.Enum.Feature.HeatmapLayer
             ) === false
-        )
+        ) {
             return;
+        }
         if (!map.hasHeatmapLayer(heatmapLayerId)) {
             const _heatmapLayer =
                 GoogleProvider.HeatmapLayer.HeatmapLayerFactory.MakeHeatmapLayer(

--- a/code/src/MapAPI/HeatmapLayerManager.ts
+++ b/code/src/MapAPI/HeatmapLayerManager.ts
@@ -79,6 +79,10 @@ namespace MapAPI.HeatmapLayerManager {
         configs: string
     ): OSFramework.HeatmapLayer.IHeatmapLayer {
         const map = GetMapByHeatmapLayerId(heatmapLayerId);
+        OSFramework.Helper.ValidateFeatureProvider(
+            map,
+            OSFramework.Enum.Feature.HeatmapLayer
+        );
         if (!map.hasHeatmapLayer(heatmapLayerId)) {
             const _heatmapLayer =
                 GoogleProvider.HeatmapLayer.HeatmapLayerFactory.MakeHeatmapLayer(

--- a/code/src/OSFramework/Enum/Feature.ts
+++ b/code/src/OSFramework/Enum/Feature.ts
@@ -1,0 +1,12 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Enum {
+    export enum Feature {
+        Marker = 'Marker',
+        MarkerPopup = 'MarkerPopup',
+        Shapes = 'Shapes',
+        Directions = 'Directions',
+        DrawingTools = 'DrawingTools',
+        FileLayer = 'FileLayer',
+        HeatmapLayer = 'HeatmapLayer'
+    }
+}

--- a/code/src/OSFramework/Helper/ValidateFeatureProvider.ts
+++ b/code/src/OSFramework/Helper/ValidateFeatureProvider.ts
@@ -1,0 +1,28 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Helper {
+    /** This is a temporary method that will allow checking if the feature is already implemented for the Leaflet provider */
+    export function ValidateFeatureProvider(
+        map: OSMap.IMap,
+        feature: Enum.Feature
+    ): boolean {
+        // If the feature is for Google Maps, then it should always be valid
+        // Else, if the feature is for Leaflet, check if it's valid depending on the feature
+        // If it's not valid, return false and throw a console warning
+        if (map.providerType === Enum.ProviderType.Google) return true;
+        switch (feature) {
+            case Enum.Feature.Marker:
+            case Enum.Feature.MarkerPopup:
+            case Enum.Feature.Shapes:
+            case Enum.Feature.Directions:
+                return true;
+            case Enum.Feature.DrawingTools:
+            case Enum.Feature.HeatmapLayer:
+            case Enum.Feature.FileLayer:
+            default:
+                console.warn(
+                    `Feature ${feature} is not implemented for the Map Leaflet`
+                );
+                return false;
+        }
+    }
+}


### PR DESCRIPTION
This PR is for RGRIDT-1108: [Maps] Add warning message to map blocks still incompatible with Leaflet

### What was happening
* We needed to add warning messages to map blocks still incompatible with Leaflet, like the Heatmap or File Layer, so our developers know it is not yet implemented.

### What was done
* Added a new method that is responsible for checking if the feature is valid or not for the specific provider. This means it will check if the feature is already implemented or not. [temporary method] 

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

