### PR TITLE
RGRDIT-1027: Bug on Google Provider setDirections [BUG]

### DIFF
--- a/code/src/GoogleProvider/Features/Directions.ts
+++ b/code/src/GoogleProvider/Features/Directions.ts
@@ -131,7 +131,7 @@ namespace GoogleProvider.Feature {
             directionOptions: OSFramework.OSStructures.Directions.Options
         ): Promise<OSFramework.OSStructures.ReturnMessage> {
             const waypts: google.maps.DirectionsWaypoint[] =
-                this._waypointsCleanup(JSON.parse(directionOptions.waypoints));
+                this._waypointsCleanup(directionOptions.waypoints);
             return (
                 this._directionsService
                     .route(

--- a/code/src/OSFramework/OSStructures/Directions.ts
+++ b/code/src/OSFramework/OSStructures/Directions.ts
@@ -6,7 +6,7 @@ namespace OSFramework.OSStructures.Directions {
         public optimizeWaypoints: boolean;
         public originRoute: string;
         public travelMode: string;
-        public waypoints: string;
+        public waypoints: Array<string>;
     }
     /** Return Message that is sent to Service Studio */
     export class ExcludeCriteria {


### PR DESCRIPTION
This PR is for RGRDIT-1027: Bug on Google Provider setDirections [BUG]

### What was happening
* Google Provider changed the way it was doing the routes. Now it doesn't need to parse the waypoints because they are already parsed once they get into the setRoute() method

### What was done
* Removed the JSON.parse from the method.

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

