### PR TITLE
Redefine z-index to 0

### DIFF
--- a/code/styles/Map.css
+++ b/code/styles/Map.css
@@ -26,7 +26,7 @@
 .runtime-map-container {
     -servicestudio-display: none!important;
     height: 100%;
-    z-index: 1;
+    z-index: 0;
 }
 
 .map-wrapper .staticMap-image {


### PR DESCRIPTION
This PR is for....

### What was happening
* In the last PR the z-index was define with value 1, because the leaflet layers have values so high that overlaps the page content
* However the value 1 broke some samples, because it'll affect the siblings as well.
* ![image](https://user-images.githubusercontent.com/60441552/149571580-b0ad055a-0c91-40d4-86b9-779ceb91442c.png)

### What was done
* redifine z-index to 0;
![image](https://user-images.githubusercontent.com/60441552/149571622-0d6a2ee7-70c4-4012-af8e-9b2fe96fa211.png)

### Test Steps
Since was a visual change:
- interact with markers, both providers;
- create 1 drawing tool and interact, google provider;
- create 1 marker and interact, both providers;
- create 1 marker popup and interact, both providers;
- interact with file layers, google provider;
- interact with heatmap, google provider;
- interact with marker clusterer, google provider;

### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

