### PR TITLE
ROU-3215 - [OSMaps] - Update Leaflet.Draw library to the latest version

### DIFF
--- a/code/package.json
+++ b/code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outsystems-maps",
-  "version": "1.0.0",
+  "version": "1.6.1",
   "description": "",
   "license": "Apache v2.0",
   "scripts": {

--- a/code/src/Providers/Leaflet/DrawingTools/DrawingTools.ts
+++ b/code/src/Providers/Leaflet/DrawingTools/DrawingTools.ts
@@ -7,7 +7,7 @@ namespace Provider.Leaflet.DrawingTools {
         //     - In that moment each tool should be boolean | NEW_TYPE because the empty state is false.
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         public circle: any;
-        public circleMarker: boolean;
+        public circlemarker: boolean;
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         public marker: any;
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
@@ -18,7 +18,7 @@ namespace Provider.Leaflet.DrawingTools {
         public rectangle: any;
 
         constructor() {
-            this.circleMarker = false; // this tool isn't provided by our experience
+            this.circlemarker = false; // this tool isn't provided by our experience
             // By default the tools are marked with false, this means that if the configs don't show up the tool will not be added (it's disabled).
             // DrawingTools is a wrapper of Tools, the configs have to be on the wrapper level (Leaflet requirement),
             // but on our experience they are provided by each Tool.
@@ -91,14 +91,12 @@ namespace Provider.Leaflet.DrawingTools {
                         break;
                     case OSFramework.Enum.DrawingToolsTypes.Marker:
                         _tools.marker = tool.options;
-
                         break;
                     case OSFramework.Enum.DrawingToolsTypes.Polygon:
                         _tools.polygon = tool.options;
                         break;
                     case OSFramework.Enum.DrawingToolsTypes.Polyline:
                         _tools.polyline = tool.options;
-
                         break;
                     case OSFramework.Enum.DrawingToolsTypes.Rectangle:
                         _tools.rectangle = tool.options;


### PR DESCRIPTION
This PR is for update the version of OutSystems Maps and fix an issue related with the update of Leaflet.Draw.

### What was happening
* Since we change the code to offer the OnDrawingChangeEvent it didn't work, because the plugin was returning duplicated coordinates (fixable with an update);
* After updating the Leaflet.Draw version we had an issue with circleMarker tool (that we have disabled by default), it starts to appear;

### What was done
* Change the DrawingTools constructor with the right naming for circlemarker.
* Update version;

### Test Steps
1. Use drawing tools, on a Leaflet map;
2. Use OnDrawingChange event;
3. Check if the coordinates returned are right;

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

