### PR TITLE
Map directions not working properly

### DIFF
--- a/code/src/OSFramework/DrawingTools/Factory.ts
+++ b/code/src/OSFramework/DrawingTools/Factory.ts
@@ -20,7 +20,9 @@ namespace OSFramework.DrawingTools {
                         configs
                     );
                 default:
-                    throw new Error(`There is no factory for the DrawingTools using the provider ${map.providerType}`);
+                    throw new Error(
+                        `There is no factory for the DrawingTools using the provider ${map.providerType}`
+                    );
             }
         }
 
@@ -49,7 +51,9 @@ namespace OSFramework.DrawingTools {
                         configs
                     );
                 default:
-                    throw new Error(`There is no factory for the Tool (${type}) using the provider ${map.providerType}`);
+                    throw new Error(
+                        `There is no factory for the Tool (${type}) using the provider ${map.providerType}`
+                    );
             }
         }
     }

--- a/code/src/OSFramework/Marker/Factory.ts
+++ b/code/src/OSFramework/Marker/Factory.ts
@@ -24,7 +24,9 @@ namespace OSFramework.Marker {
                         configs as Provider.Leaflet.Configuration.Marker.LeafletMarkerConfig
                     );
                 default:
-                    throw new Error(`There is no factory for the Marker using the provider ${map.providerType}`);
+                    throw new Error(
+                        `There is no factory for the Marker using the provider ${map.providerType}`
+                    );
             }
         }
     }

--- a/code/src/OSFramework/OSMap/Factory.ts
+++ b/code/src/OSFramework/OSMap/Factory.ts
@@ -21,7 +21,9 @@ namespace OSFramework.OSMap {
                         configs
                     );
                 default:
-                    throw new Error(`There is no factory for this Map provider (${provider})`);
+                    throw new Error(
+                        `There is no factory for this Map provider (${provider})`
+                    );
             }
         }
     }

--- a/code/src/OSFramework/Shape/Factory.ts
+++ b/code/src/OSFramework/Shape/Factory.ts
@@ -24,7 +24,9 @@ namespace OSFramework.Shape {
                         configs as JSON
                     );
                 default:
-                    throw new Error(`There is no factory for the Shape using the provider ${map.providerType}`);
+                    throw new Error(
+                        `There is no factory for the Shape using the provider ${map.providerType}`
+                    );
             }
         }
     }

--- a/code/src/OutSystems/Maps/MapAPI/Directions.ts
+++ b/code/src/OutSystems/Maps/MapAPI/Directions.ts
@@ -104,9 +104,9 @@ namespace MapAPI.Directions {
         mapId: string
     ): Promise<number> {
         OSFramework.Helper.LogWarningMessage(
-            `${OSFramework.Helper.warningMessage} 'OutSystems.Maps.MapAPI.Directions.GetTotalDistanceFromDirection()'`
+            `${OSFramework.Helper.warningMessage} 'OutSystems.Maps.MapAPI.Directions.GetTotalDurationFromDirection()'`
         );
-        return OutSystems.Maps.MapAPI.Directions.GetTotalDistanceFromDirection(
+        return OutSystems.Maps.MapAPI.Directions.GetTotalDurationFromDirection(
             mapId
         );
     }

--- a/code/src/OutSystems/Maps/MapAPI/Directions.ts
+++ b/code/src/OutSystems/Maps/MapAPI/Directions.ts
@@ -40,7 +40,7 @@ namespace OutSystems.Maps.MapAPI.Directions {
      */
     export function LoadPlugin(
         mapId: string,
-        // The provider will be an entry from LeafletProvider.Constants.Directions.Provider
+        // The provider will be an entry from Provider.Leaflet.Constants.Directions.Provider
         providerName: string,
         apiKey: string
     ): string {

--- a/code/src/OutSystems/Maps/MapAPI/DrawingToolsManager.ts
+++ b/code/src/OutSystems/Maps/MapAPI/DrawingToolsManager.ts
@@ -259,7 +259,6 @@ namespace OutSystems.Maps.MapAPI.DrawingToolsManager {
         //Try to find in DOM only if not present on Map
         const toolElement =
             OSFramework.Helper.GetElementByUniqueId(toolUniqueId);
-            
         return OSFramework.Helper.GetClosestDrawingToolsId(toolElement);
     }
 

--- a/code/src/Providers/Google/DrawingTools/Factory.ts
+++ b/code/src/Providers/Google/DrawingTools/Factory.ts
@@ -64,7 +64,9 @@ namespace Provider.Google.DrawingTools {
                         configs as Configuration.DrawingTools.DrawFilledShapeConfig
                     );
                 default:
-                    throw new Error(`There is no factory for this type of DrawingTool (${type})`);
+                    throw new Error(
+                        `There is no factory for this type of DrawingTool (${type})`
+                    );
             }
         }
     }

--- a/code/src/Providers/Google/Marker/Factory.ts
+++ b/code/src/Providers/Google/Marker/Factory.ts
@@ -13,7 +13,9 @@ namespace Provider.Google.Marker {
                 case OSFramework.Enum.MarkerType.MarkerPopup:
                     return new MarkerPopup(map, markerId, type, configs);
                 default:
-                    throw new Error(`There is no factory for this type of Marker (${type})`);
+                    throw new Error(
+                        `There is no factory for this type of Marker (${type})`
+                    );
             }
         }
     }

--- a/code/src/Providers/Google/OSMap/Factory.ts
+++ b/code/src/Providers/Google/OSMap/Factory.ts
@@ -18,7 +18,9 @@ namespace Provider.Google.OSMap {
                         configs as Configuration.OSMap.GoogleStaticMapConfig
                     );
                 default:
-                    throw new Error(`There is no factory for this type of Map (${type})`);
+                    throw new Error(
+                        `There is no factory for this type of Map (${type})`
+                    );
             }
         }
     }

--- a/code/src/Providers/Google/Shape/Factory.ts
+++ b/code/src/Providers/Google/Shape/Factory.ts
@@ -17,7 +17,9 @@ namespace Provider.Google.Shape {
                 case OSFramework.Enum.ShapeType.Rectangle:
                     return new Rectangle(map, shapeId, type, configs);
                 default:
-                    throw new Error(`There is no factory for this type of Shape (${type})`);
+                    throw new Error(
+                        `There is no factory for this type of Shape (${type})`
+                    );
             }
         }
     }

--- a/code/src/Providers/Leaflet/Constants/Directions/TravelModes.ts
+++ b/code/src/Providers/Leaflet/Constants/Directions/TravelModes.ts
@@ -11,7 +11,7 @@ namespace Provider.Leaflet.Constants.Directions.OSRM {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-namespace LeafletProvider.Constants.Directions.MapBox {
+namespace Provider.Leaflet.Constants.Directions.MapBox {
     /**
      * Enum that defines the available MapBox TravelModes
      */
@@ -23,7 +23,7 @@ namespace LeafletProvider.Constants.Directions.MapBox {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-namespace LeafletProvider.Constants.Directions.GraphHopper {
+namespace Provider.Leaflet.Constants.Directions.GraphHopper {
     /**
      * Enum that defines the available GraphHopper TravelModes
      */
@@ -35,7 +35,7 @@ namespace LeafletProvider.Constants.Directions.GraphHopper {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-namespace LeafletProvider.Constants.Directions.TomTom {
+namespace Provider.Leaflet.Constants.Directions.TomTom {
     /**
      * Enum that defines the available TomTom TravelModes
      */

--- a/code/src/Providers/Leaflet/DrawingTools/Factory.ts
+++ b/code/src/Providers/Leaflet/DrawingTools/Factory.ts
@@ -62,7 +62,9 @@ namespace Provider.Leaflet.DrawingTools {
                         configs as Configuration.DrawingTools.DrawFilledShapeConfig
                     );
                 default:
-                    throw new Error(`There is no factory for this type of Tool (${type}) using the Leaflet provider`);
+                    throw new Error(
+                        `There is no factory for this type of Tool (${type}) using the Leaflet provider`
+                    );
             }
         }
     }

--- a/code/src/Providers/Leaflet/Marker/Factory.ts
+++ b/code/src/Providers/Leaflet/Marker/Factory.ts
@@ -13,7 +13,9 @@ namespace Provider.Leaflet.Marker {
                 case OSFramework.Enum.MarkerType.MarkerPopup:
                     return new MarkerPopup(map, markerId, type, configs);
                 default:
-                    throw new Error(`There is no factory for this type of Marker (${type})`);
+                    throw new Error(
+                        `There is no factory for this type of Marker (${type})`
+                    );
             }
         }
     }

--- a/code/src/Providers/Leaflet/OSMap/Factory.ts
+++ b/code/src/Providers/Leaflet/OSMap/Factory.ts
@@ -15,7 +15,9 @@ namespace Provider.Leaflet.OSMap {
                 //Right now there is no StaticMap for the Leaflet provider
                 case OSFramework.Enum.MapType.StaticMap:
                 default:
-                    throw new Error(`There is no factory for this type of Map (${type})`);
+                    throw new Error(
+                        `There is no factory for this type of Map (${type})`
+                    );
             }
         }
     }

--- a/code/src/Providers/Leaflet/Shape/Factory.ts
+++ b/code/src/Providers/Leaflet/Shape/Factory.ts
@@ -17,7 +17,9 @@ namespace Provider.Leaflet.Shape {
                 case OSFramework.Enum.ShapeType.Rectangle:
                     return new Rectangle(map, shapeId, type, configs);
                 default:
-                    throw new Error(`There is no factory for this type of Shape (${type})`);
+                    throw new Error(
+                        `There is no factory for this type of Shape (${type})`
+                    );
             }
         }
     }


### PR DESCRIPTION
This PR is for a fix on Map directions not working properly because of namespace changes done in ROU-3077

### What was happening
* A side-effect of the work done in ROU-3077 we started having issues in the direction APIs where the method was calling the method GetTotalDistanceFromDirection instead of GetTotalDurationFromDirection
* The issue was introduced in this [commit](https://github.com/OutSystems/outsystems-maps/commit/74e9c6204176b58b075b5b99cfa2c1a3978b7461)

### What was done
* Fixed the method name
* In the OutSystemsMaps module, replaced the namespace with OutSystems.Maps.MapAPI.* on all client actions  

### Test Steps
1. Go to the test page
2. Add a start location and a destination
3. Click in Go
4. Check that the distances and time are according to the expected


### Screenshots
* Before
![image (52)](https://user-images.githubusercontent.com/29493222/168680243-e6003764-220a-4207-809c-7acad8e7d14f.png)

* With the fix
![MapsDirectionsWorking](https://user-images.githubusercontent.com/29493222/168680221-91a9edda-4d1a-45b8-a143-a8b9ed8a802d.PNG)



### Checklist
* [X] tested locally
* [X] documented the code
* [X] clean all warnings and errors of eslint
* [X] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

