### PR TITLE
ROU-3388 Update external icon position

### DIFF
--- a/code/src/Providers/Leaflet/Marker/Marker.ts
+++ b/code/src/Providers/Leaflet/Marker/Marker.ts
@@ -82,9 +82,6 @@ namespace Provider.Leaflet.Marker {
                     // get the image's size to set the location of the marker in the map correctly
                     try {
                         const { width, height } = await this._getMeta(iconUrl);
-                        console.log(
-                            `Image dimensions: ${width}px x ${height}px`
-                        );
                         this.config.iconWidth = width;
                         this.config.iconHeight = height;
                         iconSize = [

--- a/code/src/Providers/Leaflet/Marker/Marker.ts
+++ b/code/src/Providers/Leaflet/Marker/Marker.ts
@@ -38,12 +38,26 @@ namespace Provider.Leaflet.Marker {
             this._addedEvents = [];
         }
 
+        private async _getMeta(
+            url
+        ): Promise<{ width: number; height: number }> {
+            return new Promise((resolve, reject) => {
+                const img = new Image();
+                img.onload = () =>
+                    resolve({
+                        width: img.width,
+                        height: img.height
+                    });
+                img.onerror = (error) => reject(error);
+                img.src = url;
+            });
+        }
         /**
          * Sets the new icon on the Marker just by using the iconUrl
          * The width and the height of the icon will use the one in the configs (if set) or will use the default image size
          * The icon will be centered by x axis on the marker position but on the y axis it will appear right above it
          */
-        private _setIcon(iconUrl: string): void {
+        private async _setIcon(iconUrl: string) {
             let icon: L.DivIcon;
             // If the iconUrl is not set or is empty, we should use the defaultIcon
             if (iconUrl === '') {
@@ -64,6 +78,27 @@ namespace Provider.Leaflet.Marker {
                         this.config.iconWidth / 2,
                         this.config.iconHeight
                     ];
+                } else {
+                    // get the image's size to set the location of the marker in the map correctly
+                    try {
+                        const { width, height } = await this._getMeta(iconUrl);
+                        console.log(
+                            `Image dimensions: ${width}px x ${height}px`
+                        );
+                        this.config.iconWidth = width;
+                        this.config.iconHeight = height;
+                        iconSize = [
+                            this.config.iconWidth,
+                            this.config.iconHeight
+                        ];
+                        iconAnchor = [
+                            this.config.iconWidth / 2,
+                            this.config.iconHeight
+                        ];
+                    } catch (e) {
+                        // Could not load image from specified URL
+                        console.error(e);
+                    }
                 }
                 // Update the icon using the previous configurations
                 icon = new L.Icon({


### PR DESCRIPTION
This PR is for adding an extra use-case for when the user does not input any height and width when using a icon url.


### What was happening
* custom icons that had no height or width specified were being drawn not certered on the actual coordinate.

### What was done
* Added a promise to fetch the image's size before drawing it on the map.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

