### PR TITLE
Leaflet coordinates return on marker drag end

### DIFF
--- a/code/src/Providers/Leaflet/Marker/Marker.ts
+++ b/code/src/Providers/Leaflet/Marker/Marker.ts
@@ -226,10 +226,11 @@ namespace Provider.Leaflet.Marker {
                                     // EventName
                                     eventName,
                                     // Coords
-                                    e !== undefined && e.latlng !== undefined
+                                    e !== undefined &&
+                                        e.target.getLatLng() !== undefined
                                         ? JSON.stringify({
-                                              Lat: e.latlng.lat,
-                                              Lng: e.latlng.lng
+                                              Lat: e.target.getLatLng().lat,
+                                              Lng: e.target.getLatLng().lng
                                           })
                                         : undefined
                                 );

--- a/code/src/Providers/Leaflet/OSMap/OSMap.ts
+++ b/code/src/Providers/Leaflet/OSMap/OSMap.ts
@@ -80,10 +80,10 @@ namespace Provider.Leaflet.OSMap {
                                         .ProviderEvent,
                                     this,
                                     eventName,
-                                    e && e.latlng !== undefined
+                                    e && e.target.getLatLng() !== undefined
                                         ? JSON.stringify({
-                                              Lat: e.latlng.lat,
-                                              Lng: e.latlng.lng
+                                              Lat: e.target.getLatLng().lat,
+                                              Lng: e.target.getLatLng().lng
                                           })
                                         : undefined
                                 );


### PR DESCRIPTION
This PR is to fix Leaflet coordinates return on marker drag end.

### What was happening
* When using Marker's events on a Leaflet map and with drag end trigger, the coordinates were not being returned

### What was done
* Changed the path on the event object that returns the LatLong coordinates 

![MarkerEventCoordinatesLeaflet](https://user-images.githubusercontent.com/29493222/172065481-2c0d728f-9042-46b8-8b6b-33c5c2eef816.gif)


### Test Steps
1. Create a test screen with a Leaflet map
2. Add a marker
3. Set AllowDrag =True
4. Add the MarkerEvent block and set the trigger to Entities.MarkerEventTriggered.DragEnd
5. Changed the marker location and check that the coordinates are properly returned


### Checklist
* [X] tested locally
* [ ] documented the code
* [X] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

