### PR TITLE
Fixed setting default marker in Google Maps (ROU-3477)

### DIFF
--- a/code/src/Providers/Google/Marker/Marker.ts
+++ b/code/src/Providers/Google/Marker/Marker.ts
@@ -28,22 +28,36 @@ namespace Provider.Google.Marker {
         }
 
         private _setIcon(url: string): void {
-            let scaledSize: google.maps.Size;
-            // If the size of the icon is defined by a valid width and height, use those values
-            // Else If nothing is passed or the icon size has the width or the height equal to 0, use the full image size
-            if (this.config.iconWidth > 0 && this.config.iconHeight > 0) {
-                scaledSize = new google.maps.Size(
-                    this.config.iconWidth,
-                    this.config.iconHeight
-                );
+            // If the iconUrl is not set or is empty, we should use the defaultIcon
+            if (url === '') {
+                // Set the icon to the default Marker provider
+                this.provider.setIcon(null);
+            } else {
+                try {
+                    let scaledSize: google.maps.Size;
+                    // If the size of the icon is defined by a valid width and height, use those values
+                    // Else If nothing is passed or the icon size has the width or the height equal to 0, use the full image size
+                    if (
+                        this.config.iconWidth > 0 &&
+                        this.config.iconHeight > 0
+                    ) {
+                        scaledSize = new google.maps.Size(
+                            this.config.iconWidth,
+                            this.config.iconHeight
+                        );
+                    }
+                    // Update the icon using the previous configurations
+                    const icon = {
+                        url,
+                        scaledSize
+                    };
+                    // Set the icon to the Marker provider
+                    this.provider.setIcon(icon);
+                } catch (e) {
+                    // Could not load image from specified URL
+                    console.error(e);
+                }
             }
-            // Update the icon using the previous configurations
-            const icon = {
-                url,
-                scaledSize
-            };
-            // Set the icon to the Marker provider
-            this.provider.setIcon(icon);
         }
 
         /**


### PR DESCRIPTION
This PR is to fix an error when setting in runtime the default marker icon when using Google Maps.

### What was happening
* When setting in runtime the default marker icon when using Google Maps we were getting an error and no changes were applied. 
![IssueDefaultMarker](https://user-images.githubusercontent.com/29493222/172163602-aa3b97ed-2fa8-4d3b-8593-548e6a62f795.gif)

### What was done
* Added logic to check if there's an URL and if don't we'll set the Google Map's default icon

### Test Steps
1. Went to regression screen MarkerPopup
2. Set the icon URL to "Library"
3. Checked that it is applies
4. Set default
5. Checked that the default icon is reset


### Screenshots
Fixed:
![DefaultMarkerFixed](https://user-images.githubusercontent.com/29493222/172164648-b16bdd5f-bf58-481a-8059-1d7675adb718.gif)




### Checklist
* [X] tested locally
* [X] documented the code
* [X] clean all warnings and errors of eslint


