### PR TITLE
ROU-3351 - Fix usage of AsyncInvocation 

### DIFF
--- a/code/src/OSFramework/Event/AbstractEvent.ts
+++ b/code/src/OSFramework/Event/AbstractEvent.ts
@@ -50,7 +50,9 @@ namespace OSFramework.Event {
         public trigger(data?: T, ...args): void {
             this._handlers
                 .slice(0)
-                .forEach((h) => Helper.AsyncInvocation(h.eventHandler, data));
+                .forEach((h) =>
+                    Helper.CallbackAsyncInvocation(h.eventHandler, data)
+                );
         }
     }
 }

--- a/code/src/OSFramework/Event/AbstractEvent.ts
+++ b/code/src/OSFramework/Event/AbstractEvent.ts
@@ -1,5 +1,10 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.Event {
+    type Handler = {
+        eventHandler: Callbacks.Generic;
+        uniqueId: string;
+    };
+
     /**
      * Abstract class that will be responsible for the basic behaviours of a link, namely storing the callbacks.
      *
@@ -11,14 +16,20 @@ namespace OSFramework.Event {
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     export abstract class AbstractEvent<T> implements IEvent<T> {
-        private _handlers: Callbacks.Generic[] = [];
+        private _handlers: Handler[] = [];
 
-        protected get handlers(): Callbacks.Generic[] {
+        protected get handlers(): Handler[] {
             return this._handlers;
         }
 
-        public addHandler(handler: Callbacks.Generic): void {
-            this._handlers.push(handler);
+        public addHandler(
+            handler: Callbacks.Generic,
+            eventUniqueId?: string // if it's an internal event, it will not have a uniqueId
+        ): void {
+            this._handlers.push({
+                eventHandler: handler,
+                uniqueId: eventUniqueId
+            });
         }
 
         public hasHandlers(): boolean {
@@ -27,7 +38,7 @@ namespace OSFramework.Event {
 
         public removeHandler(handler: Callbacks.Generic): void {
             const index = this._handlers.findIndex((hd) => {
-                return hd === handler;
+                return hd.eventHandler === handler;
             });
 
             if (index !== -1) {
@@ -39,7 +50,7 @@ namespace OSFramework.Event {
         public trigger(data?: T, ...args): void {
             this._handlers
                 .slice(0)
-                .forEach((h) => Helper.AsyncInvocation(h, data));
+                .forEach((h) => Helper.AsyncInvocation(h.eventHandler, data));
         }
     }
 }

--- a/code/src/OSFramework/Event/AbstractEvent.ts
+++ b/code/src/OSFramework/Event/AbstractEvent.ts
@@ -2,7 +2,7 @@
 namespace OSFramework.Event {
     type Handler = {
         eventHandler: Callbacks.Generic;
-        uniqueId: string;
+        uniqueId: string; //Event unique identifier
     };
 
     /**

--- a/code/src/OSFramework/Event/AbstractEventsManager.ts
+++ b/code/src/OSFramework/Event/AbstractEventsManager.ts
@@ -23,13 +23,19 @@ namespace OSFramework.Event {
             return this._handlers;
         }
 
-        public addHandler(eventType: ET, handler: Callbacks.Generic): void {
+        public addHandler(
+            eventType: ET,
+            handler: Callbacks.Generic,
+            eventUniqueId?: string
+        ): void {
             if (this._handlers && this._handlers.has(eventType)) {
-                this._handlers.get(eventType).addHandler(handler);
+                this._handlers
+                    .get(eventType)
+                    .addHandler(handler, eventUniqueId);
             } else {
                 const ev = this.getInstanceOfEventType(eventType);
                 if (ev !== undefined) {
-                    ev.addHandler(handler);
+                    ev.addHandler(handler, eventUniqueId);
                     this._handlers.set(eventType, ev);
                 }
             }

--- a/code/src/OSFramework/Event/DrawingTools/AbstractDrawingToolsEvent.ts
+++ b/code/src/OSFramework/Event/DrawingTools/AbstractDrawingToolsEvent.ts
@@ -20,7 +20,7 @@ namespace OSFramework.Event.DrawingTools {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.AsyncInvocation(h, mapId, drawingToolsId, ...args)
+                    Helper.CallbackAsyncInvocation(h, mapId, drawingToolsId, ...args)
                 );
         }
     }

--- a/code/src/OSFramework/Event/DrawingTools/DrawingToolsProviderEvent.ts
+++ b/code/src/OSFramework/Event/DrawingTools/DrawingToolsProviderEvent.ts
@@ -30,7 +30,7 @@ namespace OSFramework.Event.DrawingTools {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.AsyncInvocation(
+                    Helper.CallbackAsyncInvocation(
                         h,
                         mapId,
                         drawingToolsId,

--- a/code/src/OSFramework/Event/FileLayer/AbstractFileLayersEvent.ts
+++ b/code/src/OSFramework/Event/FileLayer/AbstractFileLayersEvent.ts
@@ -20,7 +20,7 @@ namespace OSFramework.Event.FileLayer {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.AsyncInvocation(h, mapId, fileLayerId, ...args)
+                    Helper.CallbackAsyncInvocation(h, mapId, fileLayerId, ...args)
                 );
         }
     }

--- a/code/src/OSFramework/Event/Marker/AbstractMarkerEvent.ts
+++ b/code/src/OSFramework/Event/Marker/AbstractMarkerEvent.ts
@@ -20,7 +20,7 @@ namespace OSFramework.Event.Marker {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.AsyncInvocation(h, mapId, markerId, ...args)
+                    Helper.CallbackAsyncInvocation(h, mapId, markerId, ...args)
                 );
         }
     }

--- a/code/src/OSFramework/Event/Marker/MarkerProviderEvent.ts
+++ b/code/src/OSFramework/Event/Marker/MarkerProviderEvent.ts
@@ -26,7 +26,7 @@ namespace OSFramework.Event.Marker {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.AsyncInvocation(
+                    Helper.CallbackAsyncInvocation(
                         h,
                         mapId,
                         markerId,

--- a/code/src/OSFramework/Event/OSMap/AbstractMapEvent.ts
+++ b/code/src/OSFramework/Event/OSMap/AbstractMapEvent.ts
@@ -21,7 +21,7 @@ namespace OSFramework.Event.OSMap {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.AsyncInvocation(h, mapObj, mapId, ...args)
+                    Helper.CallbackAsyncInvocation(h, mapObj, mapId, ...args)
                 );
         }
     }

--- a/code/src/OSFramework/Event/OSMap/MapEventsManager.ts
+++ b/code/src/OSFramework/Event/OSMap/MapEventsManager.ts
@@ -62,7 +62,7 @@ namespace OSFramework.Event.OSMap {
             //if the Map is already ready, fire immediatly the event.
             if (eventType === MapEventType.Initialized && this._map.isReady) {
                 //make the invocation of the handler assync.
-                Helper.AsyncInvocation(handler, this._map, this._map.widgetId);
+                Helper.CallbackAsyncInvocation(handler, this._map, this._map.widgetId);
             } else {
                 super.addHandler(eventType, handler, eventUniqueId);
             }

--- a/code/src/OSFramework/Event/OSMap/MapEventsManager.ts
+++ b/code/src/OSFramework/Event/OSMap/MapEventsManager.ts
@@ -56,14 +56,15 @@ namespace OSFramework.Event.OSMap {
 
         public addHandler(
             eventType: MapEventType,
-            handler: Callbacks.OSMap.Event
+            handler: Callbacks.OSMap.Event,
+            eventUniqueId?: string
         ): void {
             //if the Map is already ready, fire immediatly the event.
             if (eventType === MapEventType.Initialized && this._map.isReady) {
                 //make the invocation of the handler assync.
                 Helper.AsyncInvocation(handler, this._map, this._map.widgetId);
             } else {
-                super.addHandler(eventType, handler);
+                super.addHandler(eventType, handler, eventUniqueId);
             }
         }
 

--- a/code/src/OSFramework/Event/OSMap/MapOnError.ts
+++ b/code/src/OSFramework/Event/OSMap/MapOnError.ts
@@ -26,7 +26,7 @@ namespace OSFramework.Event.OSMap {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.AsyncInvocation(
+                    Helper.CallbackAsyncInvocation(
                         h,
                         mapObj,
                         mapId,

--- a/code/src/OSFramework/Event/OSMap/MapProviderEvent.ts
+++ b/code/src/OSFramework/Event/OSMap/MapProviderEvent.ts
@@ -21,13 +21,26 @@ namespace OSFramework.Event.OSMap {
             mapObj: OSFramework.OSMap.IMap,
             mapId: string,
             eventName: string,
+            eventUniqueId: string,
             coords: string
         ): void {
-            this.handlers
-                .slice(0)
-                .forEach((h) =>
-                    Helper.AsyncInvocation(h, mapObj, mapId, eventName, coords)
-                );
+            this.handlers.slice(0).forEach((h) => {
+                // Checks if event block exists on page before calling its callback
+                if (
+                    document.querySelector(
+                        '.event-preview[name="' + h.uniqueId + '"]'
+                    )
+                ) {
+                    Helper.AsyncInvocation(
+                        h,
+                        mapObj,
+                        mapId,
+                        eventName,
+                        coords,
+                        eventUniqueId
+                    );
+                }
+            });
         }
     }
 }

--- a/code/src/OSFramework/Event/OSMap/MapProviderEvent.ts
+++ b/code/src/OSFramework/Event/OSMap/MapProviderEvent.ts
@@ -31,7 +31,7 @@ namespace OSFramework.Event.OSMap {
                         '.event-preview[name="' + h.uniqueId + '"]'
                     )
                 ) {
-                    Helper.AsyncInvocation(
+                    Helper.CallbackAsyncInvocation(
                         h,
                         mapObj,
                         mapId,

--- a/code/src/OSFramework/Event/SearchPlaces/AbstractSearchPlacesEvent.ts
+++ b/code/src/OSFramework/Event/SearchPlaces/AbstractSearchPlacesEvent.ts
@@ -21,7 +21,7 @@ namespace OSFramework.Event.SearchPlaces {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.AsyncInvocation(
+                    Helper.CallbackAsyncInvocation(
                         h,
                         searchPlacesObj,
                         searchPlacesId,

--- a/code/src/OSFramework/Event/SearchPlaces/SearchPlacesEventsManager.ts
+++ b/code/src/OSFramework/Event/SearchPlaces/SearchPlacesEventsManager.ts
@@ -57,7 +57,7 @@ namespace OSFramework.Event.SearchPlaces {
                 this._searchPlaces.isReady
             ) {
                 //make the invocation of the handler assync.
-                Helper.AsyncInvocation(
+                Helper.CallbackAsyncInvocation(
                     handler,
                     this._searchPlaces,
                     this._searchPlaces.widgetId

--- a/code/src/OSFramework/Event/SearchPlaces/SearchPlacesEventsManager.ts
+++ b/code/src/OSFramework/Event/SearchPlaces/SearchPlacesEventsManager.ts
@@ -48,7 +48,8 @@ namespace OSFramework.Event.SearchPlaces {
 
         public addHandler(
             eventType: SearchPlacesEventType,
-            handler: Callbacks.SearchPlaces.Event
+            handler: Callbacks.SearchPlaces.Event,
+            eventUniqueId: string
         ): void {
             //if the SearchPlaces is already ready, fire immediatly the event.
             if (
@@ -62,7 +63,7 @@ namespace OSFramework.Event.SearchPlaces {
                     this._searchPlaces.widgetId
                 );
             } else {
-                super.addHandler(eventType, handler);
+                super.addHandler(eventType, handler, eventUniqueId);
             }
         }
 

--- a/code/src/OSFramework/Event/SearchPlaces/SearchPlacesOnError.ts
+++ b/code/src/OSFramework/Event/SearchPlaces/SearchPlacesOnError.ts
@@ -26,7 +26,7 @@ namespace OSFramework.Event.SearchPlaces {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.AsyncInvocation(
+                    Helper.CallbackAsyncInvocation(
                         h,
                         searchPlacesObj,
                         searchPlacesId,

--- a/code/src/OSFramework/Event/Shape/AbstractShapeEvent.ts
+++ b/code/src/OSFramework/Event/Shape/AbstractShapeEvent.ts
@@ -20,7 +20,7 @@ namespace OSFramework.Event.Shape {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.AsyncInvocation(h, mapId, shapeId, ...args)
+                    Helper.CallbackAsyncInvocation(h, mapId, shapeId, ...args)
                 );
         }
     }

--- a/code/src/OSFramework/Event/Shape/ShapeProviderEvent.ts
+++ b/code/src/OSFramework/Event/Shape/ShapeProviderEvent.ts
@@ -24,7 +24,7 @@ namespace OSFramework.Event.Shape {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.AsyncInvocation(h, mapId, shapeId, eventName)
+                    Helper.CallbackAsyncInvocation(h, mapId, shapeId, eventName)
                 );
         }
     }

--- a/code/src/OSFramework/Helper/AsyncInvocation.ts
+++ b/code/src/OSFramework/Helper/AsyncInvocation.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.Helper {
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-    export function AsyncInvocation(callback: any, ...args: any) {
+    export function CallbackAsyncInvocation(callback: any, ...args: any) {
         if (callback.eventHandler)
             setTimeout(() => callback.eventHandler(...args), 0);
     }

--- a/code/src/OSFramework/Helper/AsyncInvocation.ts
+++ b/code/src/OSFramework/Helper/AsyncInvocation.ts
@@ -1,7 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.Helper {
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-    export function AsyncInvocation(callback: Callbacks.Generic, ...args: any) {
-        if (callback) setTimeout(() => callback(...args), 0);
+    export function AsyncInvocation(callback: any, ...args: any) {
+        if (callback.eventHandler)
+            setTimeout(() => callback.eventHandler(...args), 0);
     }
 }

--- a/code/src/OutSystems/Maps/MapAPI/DrawingToolsManager.Events.ts
+++ b/code/src/OutSystems/Maps/MapAPI/DrawingToolsManager.Events.ts
@@ -7,7 +7,7 @@ namespace OutSystems.Maps.MapAPI.DrawingToolsManager.Events {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.DrawingTools.DrawingToolsEventType;
-            uniqueId: string;
+            uniqueId: string; //Event unique identifier
         }[]
     > = new Map<
         string,
@@ -15,7 +15,7 @@ namespace OutSystems.Maps.MapAPI.DrawingToolsManager.Events {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.DrawingTools.DrawingToolsEventType;
-            uniqueId: string;
+            uniqueId: string; //Event unique identifier
         }[]
     >();
 

--- a/code/src/OutSystems/Maps/MapAPI/DrawingToolsManager.Events.ts
+++ b/code/src/OutSystems/Maps/MapAPI/DrawingToolsManager.Events.ts
@@ -7,13 +7,15 @@ namespace OutSystems.Maps.MapAPI.DrawingToolsManager.Events {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.DrawingTools.DrawingToolsEventType;
+            uniqueId: string;
         }[]
     > = new Map<
         string,
         {
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.DrawingTools.DrawingToolsEventType;
+            uniqueId: string;
         }[]
     >();
 
@@ -32,7 +34,8 @@ namespace OutSystems.Maps.MapAPI.DrawingToolsManager.Events {
                 _pendingEvents.get(key).forEach((obj) => {
                     drawingTools.drawingToolsEvents.addHandler(
                         obj.event,
-                        obj.cb
+                        obj.cb,
+                        obj.uniqueId
                     );
                 });
                 drawingTools.refreshProviderEvents();
@@ -53,7 +56,6 @@ namespace OutSystems.Maps.MapAPI.DrawingToolsManager.Events {
     export function SubscribeByToolUniqueId(
         toolUniqueId: string,
         eventName: OSFramework.Event.DrawingTools.DrawingToolsEventType,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         callback: OSFramework.Callbacks.DrawingTools.Event
     ): void {
         // Let's make sure that if the Map doesn't exist, we don't throw and exception but instead add the handler to the pendingEvents
@@ -64,18 +66,24 @@ namespace OutSystems.Maps.MapAPI.DrawingToolsManager.Events {
             if (_pendingEvents.has(drawingToolsId)) {
                 _pendingEvents.get(drawingToolsId).push({
                     event: eventName,
-                    cb: callback
+                    cb: callback,
+                    uniqueId: toolUniqueId
                 });
             } else {
                 _pendingEvents.set(drawingToolsId, [
                     {
                         event: eventName,
-                        cb: callback
+                        cb: callback,
+                        uniqueId: toolUniqueId
                     }
                 ]);
             }
         } else {
-            drawingTools.drawingToolsEvents.addHandler(eventName, callback);
+            drawingTools.drawingToolsEvents.addHandler(
+                eventName,
+                callback,
+                toolUniqueId
+            );
         }
     }
 
@@ -90,7 +98,6 @@ namespace OutSystems.Maps.MapAPI.DrawingToolsManager.Events {
     export function UnsubscribeByToolId(
         toolUniqueId: string,
         eventName: OSFramework.Event.DrawingTools.DrawingToolsEventType,
-        // eslint-disable-next-line
         callback: OSFramework.Callbacks.DrawingTools.Event
     ): void {
         const drawingToolsId = GetDrawingToolsByToolUniqueId(toolUniqueId);
@@ -135,7 +142,6 @@ namespace MapAPI.DrawingToolsManager.Events {
     export function SubscribeByToolUniqueId(
         toolUniqueId: string,
         eventName: OSFramework.Event.DrawingTools.DrawingToolsEventType,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         callback: OSFramework.Callbacks.DrawingTools.Event
     ): void {
         OSFramework.Helper.LogWarningMessage(
@@ -151,7 +157,6 @@ namespace MapAPI.DrawingToolsManager.Events {
     export function UnsubscribeByToolId(
         toolUniqueId: string,
         eventName: OSFramework.Event.DrawingTools.DrawingToolsEventType,
-        // eslint-disable-next-line
         callback: OSFramework.Callbacks.DrawingTools.Event
     ): void {
         OSFramework.Helper.LogWarningMessage(

--- a/code/src/OutSystems/Maps/MapAPI/DrawingToolsManager.ts
+++ b/code/src/OutSystems/Maps/MapAPI/DrawingToolsManager.ts
@@ -87,7 +87,6 @@ namespace OutSystems.Maps.MapAPI.DrawingToolsManager {
         toolId: string,
         type: OSFramework.Enum.DrawingToolsTypes,
         configs: string
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): OSFramework.DrawingTools.ITool {
         // Let's make sure that if the Map doesn't exist, we don't throw and exception but instead add the handler to the pendingEvents
         const drawingToolsId = GetDrawingToolsByToolUniqueId(toolId);
@@ -300,7 +299,6 @@ namespace MapAPI.DrawingToolsManager {
         toolId: string,
         type: OSFramework.Enum.DrawingToolsTypes,
         configs: string
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): OSFramework.DrawingTools.ITool {
         OSFramework.Helper.LogWarningMessage(
             `${OSFramework.Helper.warningMessage} 'OutSystems.Maps.MapAPI.DrawingToolsManager.AddTool()'`

--- a/code/src/OutSystems/Maps/MapAPI/FileLayerManager.Events.ts
+++ b/code/src/OutSystems/Maps/MapAPI/FileLayerManager.Events.ts
@@ -7,7 +7,7 @@ namespace OutSystems.Maps.MapAPI.FileLayerManager.Events {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.FileLayer.FileLayersEventType;
-            uniqueId: string;
+            uniqueId: string; //Event unique identifier
         }[]
     > = new Map<
         string,
@@ -15,7 +15,7 @@ namespace OutSystems.Maps.MapAPI.FileLayerManager.Events {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.FileLayer.FileLayersEventType;
-            uniqueId: string;
+            uniqueId: string; //Event unique identifier
         }[]
     >();
 

--- a/code/src/OutSystems/Maps/MapAPI/FileLayerManager.Events.ts
+++ b/code/src/OutSystems/Maps/MapAPI/FileLayerManager.Events.ts
@@ -7,13 +7,15 @@ namespace OutSystems.Maps.MapAPI.FileLayerManager.Events {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.FileLayer.FileLayersEventType;
+            uniqueId: string;
         }[]
     > = new Map<
         string,
         {
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.FileLayer.FileLayersEventType;
+            uniqueId: string;
         }[]
     >();
 
@@ -30,7 +32,11 @@ namespace OutSystems.Maps.MapAPI.FileLayerManager.Events {
         for (const key of _pendingEvents.keys()) {
             if (fileLayer.equalsToID(key)) {
                 _pendingEvents.get(key).forEach((obj) => {
-                    fileLayer.fileLayerEvents.addHandler(obj.event, obj.cb);
+                    fileLayer.fileLayerEvents.addHandler(
+                        obj.event,
+                        obj.cb,
+                        obj.uniqueId
+                    );
                 });
                 fileLayer.refreshProviderEvents();
                 // Make sure to delete the entry from the pendingEvents
@@ -58,18 +64,24 @@ namespace OutSystems.Maps.MapAPI.FileLayerManager.Events {
             if (_pendingEvents.has(fileLayerId)) {
                 _pendingEvents.get(fileLayerId).push({
                     event: eventName,
-                    cb: callback
+                    cb: callback,
+                    uniqueId: fileLayerId
                 });
             } else {
                 _pendingEvents.set(fileLayerId, [
                     {
                         event: eventName,
-                        cb: callback
+                        cb: callback,
+                        uniqueId: fileLayerId
                     }
                 ]);
             }
         } else {
-            fileLayer.fileLayerEvents.addHandler(eventName, callback);
+            fileLayer.fileLayerEvents.addHandler(
+                eventName,
+                callback,
+                fileLayerId
+            );
             fileLayer.refreshProviderEvents();
         }
     }

--- a/code/src/OutSystems/Maps/MapAPI/MapManager.Events.ts
+++ b/code/src/OutSystems/Maps/MapAPI/MapManager.Events.ts
@@ -3,12 +3,20 @@ namespace OutSystems.Maps.MapAPI.MapManager.Events {
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
     const _pendingEvents: Map<
         string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        { cb: any; event: OSFramework.Event.OSMap.MapEventType }[]
+        {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            cb: any;
+            event: OSFramework.Event.OSMap.MapEventType;
+            uniqueId: string;
+        }[]
     > = new Map<
         string,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        { cb: any; event: OSFramework.Event.OSMap.MapEventType }[]
+        {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            cb: any;
+            event: OSFramework.Event.OSMap.MapEventType;
+            uniqueId: string;
+        }[]
     >();
 
     const _eventsToMapId = new Map<string, string>(); //event.uniqueId -> map.uniqueId
@@ -24,7 +32,7 @@ namespace OutSystems.Maps.MapAPI.MapManager.Events {
         for (const key of _pendingEvents.keys()) {
             if (map.equalsToID(key)) {
                 _pendingEvents.get(key).forEach((obj) => {
-                    map.mapEvents.addHandler(obj.event, obj.cb);
+                    map.mapEvents.addHandler(obj.event, obj.cb, obj.uniqueId);
                 });
                 // Make sure to delete the entry from the pendingEvents
                 _pendingEvents.delete(key);
@@ -77,13 +85,15 @@ namespace OutSystems.Maps.MapAPI.MapManager.Events {
             if (_pendingEvents.has(mapId)) {
                 _pendingEvents.get(mapId).push({
                     event: eventName,
-                    cb: callback
+                    cb: callback,
+                    uniqueId: mapId
                 });
             } else {
                 _pendingEvents.set(mapId, [
                     {
                         event: eventName,
-                        cb: callback
+                        cb: callback,
+                        uniqueId: mapId
                     }
                 ]);
             }
@@ -101,31 +111,32 @@ namespace OutSystems.Maps.MapAPI.MapManager.Events {
      * @param {MapAPI.Callbacks.OSMap.Event} callback callback to be invoked when the event occurs
      */
     export function SubscribeByUniqueId(
-        uniqueId: string,
+        eventUniqueId: string,
         eventName: OSFramework.Event.OSMap.MapEventType,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         callback: OSFramework.Callbacks.OSMap.Event
     ): void {
         // Let's make sure that if the Map doesn't exist, we don't throw and exception but instead add the handler to the pendingEvents
-        const mapId = GetMapByEventUniqueId(uniqueId);
+        const mapId = GetMapByEventUniqueId(eventUniqueId);
         const map = GetMapById(mapId, false);
 
         if (map === undefined) {
             if (_pendingEvents.has(mapId)) {
                 _pendingEvents.get(mapId).push({
                     event: eventName,
-                    cb: callback
+                    cb: callback,
+                    uniqueId: eventUniqueId
                 });
             } else {
                 _pendingEvents.set(mapId, [
                     {
                         event: eventName,
-                        cb: callback
+                        cb: callback,
+                        uniqueId: eventUniqueId
                     }
                 ]);
             }
         } else {
-            map.mapEvents.addHandler(eventName, callback);
+            map.mapEvents.addHandler(eventName, callback, eventUniqueId);
             map.refreshProviderEvents();
         }
     }
@@ -141,7 +152,6 @@ namespace OutSystems.Maps.MapAPI.MapManager.Events {
     export function Unsubscribe(
         eventUniqueId: string,
         eventName: OSFramework.Event.OSMap.MapEventType,
-        // eslint-disable-next-line
         callback: OSFramework.Callbacks.OSMap.Event
     ): void {
         const mapId = GetMapByEventUniqueId(eventUniqueId);
@@ -193,7 +203,6 @@ namespace MapAPI.MapManager.Events {
     export function Subscribe(
         mapId: string,
         eventName: OSFramework.Event.OSMap.MapEventType,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         callback: OSFramework.Callbacks.OSMap.Event
     ): void {
         OSFramework.Helper.LogWarningMessage(
@@ -209,7 +218,6 @@ namespace MapAPI.MapManager.Events {
     export function SubscribeByUniqueId(
         uniqueId: string,
         eventName: OSFramework.Event.OSMap.MapEventType,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         callback: OSFramework.Callbacks.OSMap.Event
     ): void {
         OSFramework.Helper.LogWarningMessage(
@@ -225,7 +233,6 @@ namespace MapAPI.MapManager.Events {
     export function Unsubscribe(
         eventUniqueId: string,
         eventName: OSFramework.Event.OSMap.MapEventType,
-        // eslint-disable-next-line
         callback: OSFramework.Callbacks.OSMap.Event
     ): void {
         OSFramework.Helper.LogWarningMessage(

--- a/code/src/OutSystems/Maps/MapAPI/MapManager.Events.ts
+++ b/code/src/OutSystems/Maps/MapAPI/MapManager.Events.ts
@@ -7,7 +7,7 @@ namespace OutSystems.Maps.MapAPI.MapManager.Events {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.OSMap.MapEventType;
-            uniqueId: string;
+            uniqueId: string; //Event unique identifier
         }[]
     > = new Map<
         string,
@@ -15,7 +15,7 @@ namespace OutSystems.Maps.MapAPI.MapManager.Events {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.OSMap.MapEventType;
-            uniqueId: string;
+            uniqueId: string; //Event unique identifier
         }[]
     >();
 

--- a/code/src/OutSystems/Maps/MapAPI/MarkerManager.Events.ts
+++ b/code/src/OutSystems/Maps/MapAPI/MarkerManager.Events.ts
@@ -3,12 +3,20 @@ namespace OutSystems.Maps.MapAPI.MarkerManager.Events {
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
     const _pendingEvents: Map<
         string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        { cb: any; event: OSFramework.Event.Marker.MarkerEventType }[]
+        {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            cb: any;
+            event: OSFramework.Event.Marker.MarkerEventType;
+            uniqueId: string;
+        }[]
     > = new Map<
         string,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        { cb: any; event: OSFramework.Event.Marker.MarkerEventType }[]
+        {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            cb: any;
+            event: OSFramework.Event.Marker.MarkerEventType;
+            uniqueId: string;
+        }[]
     >();
 
     const _eventsToMarkerId = new Map<string, string>(); //event.uniqueId -> marker.uniqueId
@@ -26,7 +34,11 @@ namespace OutSystems.Maps.MapAPI.MarkerManager.Events {
         for (const key of _pendingEvents.keys()) {
             if (marker.equalsToID(key)) {
                 _pendingEvents.get(key).forEach((obj) => {
-                    marker.markerEvents.addHandler(obj.event, obj.cb);
+                    marker.markerEvents.addHandler(
+                        obj.event,
+                        obj.cb,
+                        obj.uniqueId
+                    );
                 });
                 // Make sure to delete the entry from the pendingEvents
                 _pendingEvents.delete(key);
@@ -71,7 +83,7 @@ namespace OutSystems.Maps.MapAPI.MarkerManager.Events {
         callback: OSFramework.Callbacks.Marker.Event
     ): void {
         const marker = GetMarkerById(markerId);
-        marker.markerEvents.addHandler(eventName, callback);
+        marker.markerEvents.addHandler(eventName, callback, markerId);
     }
 
     /**
@@ -96,18 +108,20 @@ namespace OutSystems.Maps.MapAPI.MarkerManager.Events {
             if (_pendingEvents.has(markerId)) {
                 _pendingEvents.get(markerId).push({
                     event: eventName,
-                    cb: callback
+                    cb: callback,
+                    uniqueId: eventUniqueId
                 });
             } else {
                 _pendingEvents.set(markerId, [
                     {
                         event: eventName,
-                        cb: callback
+                        cb: callback,
+                        uniqueId: eventUniqueId
                     }
                 ]);
             }
         } else {
-            marker.markerEvents.addHandler(eventName, callback);
+            marker.markerEvents.addHandler(eventName, callback, eventUniqueId);
         }
     }
 
@@ -126,7 +140,7 @@ namespace OutSystems.Maps.MapAPI.MarkerManager.Events {
     ): void {
         const map = MapManager.GetMapById(mapId);
         map.markers.forEach((marker) => {
-            marker.markerEvents.addHandler(eventName, callback);
+            marker.markerEvents.addHandler(eventName, callback, mapId);
         });
     }
 

--- a/code/src/OutSystems/Maps/MapAPI/MarkerManager.Events.ts
+++ b/code/src/OutSystems/Maps/MapAPI/MarkerManager.Events.ts
@@ -7,7 +7,7 @@ namespace OutSystems.Maps.MapAPI.MarkerManager.Events {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.Marker.MarkerEventType;
-            uniqueId: string;
+            uniqueId: string; //Event unique identifier
         }[]
     > = new Map<
         string,
@@ -15,7 +15,7 @@ namespace OutSystems.Maps.MapAPI.MarkerManager.Events {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.Marker.MarkerEventType;
-            uniqueId: string;
+            uniqueId: string; //Event unique identifier
         }[]
     >();
 

--- a/code/src/OutSystems/Maps/MapAPI/ShapeManager.Events.ts
+++ b/code/src/OutSystems/Maps/MapAPI/ShapeManager.Events.ts
@@ -3,12 +3,20 @@ namespace OutSystems.Maps.MapAPI.ShapeManager.Events {
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
     const _pendingEvents: Map<
         string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        { cb: any; event: OSFramework.Event.Shape.ShapeEventType }[]
+        {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            cb: any;
+            event: OSFramework.Event.Shape.ShapeEventType;
+            uniqueId: string;
+        }[]
     > = new Map<
         string,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        { cb: any; event: OSFramework.Event.Shape.ShapeEventType }[]
+        {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            cb: any;
+            event: OSFramework.Event.Shape.ShapeEventType;
+            uniqueId: string;
+        }[]
     >();
 
     const _eventsToShapeId = new Map<string, string>(); //event.uniqueId -> shape.uniqueId
@@ -24,7 +32,11 @@ namespace OutSystems.Maps.MapAPI.ShapeManager.Events {
         for (const key of _pendingEvents.keys()) {
             if (shape.equalsToID(key)) {
                 _pendingEvents.get(key).forEach((obj) => {
-                    shape.shapeEvents.addHandler(obj.event, obj.cb);
+                    shape.shapeEvents.addHandler(
+                        obj.event,
+                        obj.cb,
+                        obj.uniqueId
+                    );
                 });
                 // Make sure to delete the entry from the pendingEvents
                 _pendingEvents.delete(key);
@@ -67,7 +79,7 @@ namespace OutSystems.Maps.MapAPI.ShapeManager.Events {
         callback: OSFramework.Callbacks.Shape.Event
     ): void {
         const shape = GetShapeById(shapeId);
-        shape.shapeEvents.addHandler(eventName, callback);
+        shape.shapeEvents.addHandler(eventName, callback, shapeId);
     }
 
     /**
@@ -92,18 +104,20 @@ namespace OutSystems.Maps.MapAPI.ShapeManager.Events {
             if (_pendingEvents.has(shapeId)) {
                 _pendingEvents.get(shapeId).push({
                     event: eventName,
-                    cb: callback
+                    cb: callback,
+                    uniqueId: eventUniqueId
                 });
             } else {
                 _pendingEvents.set(shapeId, [
                     {
                         event: eventName,
-                        cb: callback
+                        cb: callback,
+                        uniqueId: eventUniqueId
                     }
                 ]);
             }
         } else {
-            shape.shapeEvents.addHandler(eventName, callback);
+            shape.shapeEvents.addHandler(eventName, callback, eventUniqueId);
             shape.refreshProviderEvents();
         }
     }

--- a/code/src/OutSystems/Maps/MapAPI/ShapeManager.Events.ts
+++ b/code/src/OutSystems/Maps/MapAPI/ShapeManager.Events.ts
@@ -7,7 +7,7 @@ namespace OutSystems.Maps.MapAPI.ShapeManager.Events {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.Shape.ShapeEventType;
-            uniqueId: string;
+            uniqueId: string; //Event unique identifier
         }[]
     > = new Map<
         string,
@@ -15,7 +15,7 @@ namespace OutSystems.Maps.MapAPI.ShapeManager.Events {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.Shape.ShapeEventType;
-            uniqueId: string;
+            uniqueId: string; //Event unique identifier
         }[]
     >();
 

--- a/code/src/OutSystems/Maps/PlacesAPI/SearchPlacesManager.Events.ts
+++ b/code/src/OutSystems/Maps/PlacesAPI/SearchPlacesManager.Events.ts
@@ -7,6 +7,7 @@ namespace OutSystems.Maps.PlacesAPI.SearchPlacesManager.Events {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.SearchPlaces.SearchPlacesEventType;
+            uniqueId: string;
         }[]
     > = new Map<
         string,
@@ -14,6 +15,7 @@ namespace OutSystems.Maps.PlacesAPI.SearchPlacesManager.Events {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             cb: any;
             event: OSFramework.Event.SearchPlaces.SearchPlacesEventType;
+            uniqueId: string;
         }[]
     >();
 
@@ -34,7 +36,8 @@ namespace OutSystems.Maps.PlacesAPI.SearchPlacesManager.Events {
                 _pendingEvents.get(key).forEach((obj) => {
                     searchPlaces.searchPlacesEvents.addHandler(
                         obj.event,
-                        obj.cb
+                        obj.cb,
+                        obj.uniqueId
                     );
                 });
                 // Make sure to delete the entry from the pendingEvents
@@ -79,7 +82,6 @@ namespace OutSystems.Maps.PlacesAPI.SearchPlacesManager.Events {
     export function Subscribe(
         searchPlacesId: string,
         eventName: OSFramework.Event.SearchPlaces.SearchPlacesEventType,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         callback: OSFramework.Callbacks.SearchPlaces.Event
     ): void {
         // Let's make sure that if the SearchPlaces doesn't exist, we don't throw and exception but instead add the handler to the pendingEvents
@@ -88,18 +90,24 @@ namespace OutSystems.Maps.PlacesAPI.SearchPlacesManager.Events {
             if (_pendingEvents.has(searchPlacesId)) {
                 _pendingEvents.get(searchPlacesId).push({
                     event: eventName,
-                    cb: callback
+                    cb: callback,
+                    uniqueId: searchPlacesId
                 });
             } else {
                 _pendingEvents.set(searchPlacesId, [
                     {
                         event: eventName,
-                        cb: callback
+                        cb: callback,
+                        uniqueId: searchPlacesId
                     }
                 ]);
             }
         } else {
-            searchPlaces.searchPlacesEvents.addHandler(eventName, callback);
+            searchPlaces.searchPlacesEvents.addHandler(
+                eventName,
+                callback,
+                searchPlacesId
+            );
         }
     }
 
@@ -114,7 +122,6 @@ namespace OutSystems.Maps.PlacesAPI.SearchPlacesManager.Events {
     export function Unsubscribe(
         eventUniqueId: string,
         eventName: OSFramework.Event.SearchPlaces.SearchPlacesEventType,
-        // eslint-disable-next-line
         callback: OSFramework.Callbacks.SearchPlaces.Event
     ): void {
         const searchPlacesId = GetSearchPlacesByEventUniqueId(eventUniqueId);
@@ -171,7 +178,6 @@ namespace PlacesAPI.SearchPlacesManager.Events {
     export function Subscribe(
         searchPlacesId: string,
         eventName: OSFramework.Event.SearchPlaces.SearchPlacesEventType,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         callback: OSFramework.Callbacks.SearchPlaces.Event
     ): void {
         OSFramework.Helper.LogWarningMessage(
@@ -187,7 +193,6 @@ namespace PlacesAPI.SearchPlacesManager.Events {
     export function Unsubscribe(
         eventUniqueId: string,
         eventName: OSFramework.Event.SearchPlaces.SearchPlacesEventType,
-        // eslint-disable-next-line
         callback: OSFramework.Callbacks.SearchPlaces.Event
     ): void {
         OSFramework.Helper.LogWarningMessage(


### PR DESCRIPTION
### What was happening
* When other assets, with the AsyncInvocation function available, were on the page their interactions stop to work since the input parameter structure change after this branch implementation.

### What was done
* Rename common function (AsyncInvocation) to prevent usage from other Assets.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems
* [ ] requires new sample page in OutSystems 

