### PR TITLE
ROU-3687: Fixing marker on click

### DIFF
--- a/src/OSFramework/Maps/Event/OSMap/MapProviderEvent.ts
+++ b/src/OSFramework/Maps/Event/OSMap/MapProviderEvent.ts
@@ -21,8 +21,8 @@ namespace OSFramework.Maps.Event.OSMap {
             mapObj: OSFramework.Maps.OSMap.IMap,
             mapId: string,
             eventName: string,
-            eventUniqueId: string,
-            coords: string
+            coords: string,
+            eventUniqueId: string
         ): void {
             this.handlers.slice(0).forEach((h) => {
                 // Checks if event block exists on page before calling its callback


### PR DESCRIPTION
This PR fixes a bug where marker click event wasn't receiving correct coordinates.


### What was happening
* This was a side effect introduced in #104. We changed the coordinates parameter order.

### What was done
* Adjusted the parameter order.

### Test Steps
1. Click anywhere in the map.
Expected: A marker should be created on the place you clicked.

1. Open console
2. Press current screen button

Expected: No error should appear on console.

