### PR TITLE
ROU-3692: Google Maps Marker doesn't appear in some samples

### DIFF
--- a/src/OSFramework/Maps/Event/DrawingTools/AbstractDrawingToolsEvent.ts
+++ b/src/OSFramework/Maps/Event/DrawingTools/AbstractDrawingToolsEvent.ts
@@ -20,7 +20,12 @@ namespace OSFramework.Maps.Event.DrawingTools {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.CallbackAsyncInvocation(h, mapId, drawingToolsId, ...args)
+                    Helper.CallbackAsyncInvocation(
+                        h,
+                        mapId,
+                        drawingToolsId,
+                        ...args
+                    )
                 );
         }
     }

--- a/src/OSFramework/Maps/Event/FileLayer/AbstractFileLayersEvent.ts
+++ b/src/OSFramework/Maps/Event/FileLayer/AbstractFileLayersEvent.ts
@@ -20,7 +20,12 @@ namespace OSFramework.Maps.Event.FileLayer {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.CallbackAsyncInvocation(h, mapId, fileLayerId, ...args)
+                    Helper.CallbackAsyncInvocation(
+                        h,
+                        mapId,
+                        fileLayerId,
+                        ...args
+                    )
                 );
         }
     }

--- a/src/OSFramework/Maps/Event/OSMap/MapEventsManager.ts
+++ b/src/OSFramework/Maps/Event/OSMap/MapEventsManager.ts
@@ -62,7 +62,11 @@ namespace OSFramework.Maps.Event.OSMap {
             //if the Map is already ready, fire immediatly the event.
             if (eventType === MapEventType.Initialized && this._map.isReady) {
                 //make the invocation of the handler assync.
-                Helper.CallbackAsyncInvocation(handler, this._map, this._map.widgetId);
+                Helper.CallbackAsyncInvocation(
+                    handler,
+                    this._map,
+                    this._map.widgetId
+                );
             } else {
                 super.addHandler(eventType, handler, eventUniqueId);
             }

--- a/src/OSFramework/Maps/Feature/ICenter.ts
+++ b/src/OSFramework/Maps/Feature/ICenter.ts
@@ -10,7 +10,9 @@ namespace OSFramework.Maps.Feature {
         /** Refreshes the Current Center position of the Map
          * Changes whenever a marker is added or by enabling the Autofit on Zoom feature
          */
-        refreshCenter(value: OSFramework.Maps.OSStructures.OSMap.Coordinates): void;
+        refreshCenter(
+            value: OSFramework.Maps.OSStructures.OSMap.Coordinates
+        ): void;
         /** Set Current center position of the Map */
         setCurrentCenter(
             value: OSFramework.Maps.OSStructures.OSMap.Coordinates

--- a/src/OSFramework/Maps/OSMap/IMap.ts
+++ b/src/OSFramework/Maps/OSMap/IMap.ts
@@ -70,7 +70,9 @@ namespace OSFramework.Maps.OSMap {
          * @param shape Shape that will be added to the Map
          * @returns Shape that has been created
          */
-        addShape(shape: OSFramework.Maps.Shape.IShape): OSFramework.Maps.Shape.IShape;
+        addShape(
+            shape: OSFramework.Maps.Shape.IShape
+        ): OSFramework.Maps.Shape.IShape;
         /**
          * Change property of a drawingTools from the DrawingTools by specifying the property name and the new value
          * @param drawingToolsId id of the DrawingTools
@@ -143,7 +145,9 @@ namespace OSFramework.Maps.OSMap {
          * @param fileLayerId id of the FileLayer
          * @returns FileLayer found via the specified fileLayerId
          */
-        getFileLayer(fileLayerId: string): OSFramework.Maps.FileLayer.IFileLayer;
+        getFileLayer(
+            fileLayerId: string
+        ): OSFramework.Maps.FileLayer.IFileLayer;
         /**
          * Get the Marker from the Map by giving a markerId
          * @param markerId id of the marker

--- a/src/OutSystems/Maps/MapAPI/DrawingToolsManager.ts
+++ b/src/OutSystems/Maps/MapAPI/DrawingToolsManager.ts
@@ -19,13 +19,14 @@ namespace OutSystems.Maps.MapAPI.DrawingToolsManager {
             !drawingTools.hasTool(toolId) &&
             !drawingTools.toolAlreadyExists(type)
         ) {
-            const _tool = OSFramework.Maps.DrawingTools.DrawingToolsFactory.MakeTool(
-                drawingTools.map,
-                drawingTools,
-                toolId,
-                type,
-                JSON.parse(configs)
-            );
+            const _tool =
+                OSFramework.Maps.DrawingTools.DrawingToolsFactory.MakeTool(
+                    drawingTools.map,
+                    drawingTools,
+                    toolId,
+                    type,
+                    JSON.parse(configs)
+                );
             drawingTools.addTool(_tool);
             Events.CheckPendingEvents(drawingTools);
             return _tool;

--- a/src/OutSystems/Maps/MapAPI/FileLayerManager.ts
+++ b/src/OutSystems/Maps/MapAPI/FileLayerManager.ts
@@ -9,7 +9,9 @@ namespace OutSystems.Maps.MapAPI.FileLayerManager {
      * @param {string} fileLayerId Id of the FileLayer that exists on the Map
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    function GetMapByFileLayerId(fileLayerId: string): OSFramework.Maps.OSMap.IMap {
+    function GetMapByFileLayerId(
+        fileLayerId: string
+    ): OSFramework.Maps.OSMap.IMap {
         let map: OSFramework.Maps.OSMap.IMap;
 
         //fileLayerId is the UniqueId
@@ -111,9 +113,8 @@ namespace OutSystems.Maps.MapAPI.FileLayerManager {
         fileLayerId: string,
         raiseError = true
     ): OSFramework.Maps.FileLayer.IFileLayer {
-        const fileLayer: OSFramework.Maps.FileLayer.IFileLayer = fileLayerArr.find(
-            (p) => p && p.equalsToID(fileLayerId)
-        );
+        const fileLayer: OSFramework.Maps.FileLayer.IFileLayer =
+            fileLayerArr.find((p) => p && p.equalsToID(fileLayerId));
 
         if (fileLayer === undefined && raiseError) {
             throw new Error(`FileLayer id:${fileLayerId} not found`);

--- a/src/OutSystems/Maps/MapAPI/HeatmapLayerManager.ts
+++ b/src/OutSystems/Maps/MapAPI/HeatmapLayerManager.ts
@@ -1,7 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OutSystems.Maps.MapAPI.HeatmapLayerManager {
     const heatmapLayerMap = new Map<string, string>(); //heatmapLayer.uniqueId -> map.uniqueId
-    const heatmapLayerArr = new Array<OSFramework.Maps.HeatmapLayer.IHeatmapLayer>();
+    const heatmapLayerArr =
+        new Array<OSFramework.Maps.HeatmapLayer.IHeatmapLayer>();
 
     /**
      * Gets the Map to which the HeatmapLayer belongs to

--- a/src/OutSystems/Maps/MapAPI/MapManager.ts
+++ b/src/OutSystems/Maps/MapAPI/MapManager.ts
@@ -120,7 +120,10 @@ namespace OutSystems.Maps.MapAPI.MapManager {
      * Function that will get all the maps from the current page
      * @returns Map structure containing all the maps and the corresponding uniqueId
      */
-    export function GetMapsFromPage(): Map<string, OSFramework.Maps.OSMap.IMap> {
+    export function GetMapsFromPage(): Map<
+        string,
+        OSFramework.Maps.OSMap.IMap
+    > {
         return maps;
     }
 
@@ -195,9 +198,9 @@ namespace OutSystems.Maps.MapAPI.MapManager {
         //It would imply that the widgetId would be set in a different moment than what is now.
         //*************************************/
         if (widgetId === undefined) {
-            widgetId = OSFramework.Maps.Helper.GetElementByUniqueId(mapId).closest(
-                map.mapTag
-            ).id;
+            widgetId = OSFramework.Maps.Helper.GetElementByUniqueId(
+                mapId
+            ).closest(map.mapTag).id;
         }
         //*************************************/
 
@@ -293,7 +296,10 @@ namespace MapAPI.MapManager {
         return OutSystems.Maps.MapAPI.MapManager.GetMapById(mapId, raiseError);
     }
 
-    export function GetMapsFromPage(): Map<string, OSFramework.Maps.OSMap.IMap> {
+    export function GetMapsFromPage(): Map<
+        string,
+        OSFramework.Maps.OSMap.IMap
+    > {
         OSFramework.Maps.Helper.LogWarningMessage(
             `${OSFramework.Maps.Helper.warningMessage} 'OutSystems.Maps.MapAPI.MapManager.GetMapsFromPage()'`
         );

--- a/src/OutSystems/Maps/MapAPI/MarkerManager.ts
+++ b/src/OutSystems/Maps/MapAPI/MarkerManager.ts
@@ -62,12 +62,13 @@ namespace OutSystems.Maps.MapAPI.MarkerManager {
     ): OSFramework.Maps.Marker.IMarker {
         const map = MapManager.GetMapById(mapId, true);
         if (!map.hasMarker(markerId)) {
-            const _marker = Provider.Maps.Google.Marker.MarkerFactory.MakeMarker(
-                map,
-                markerId,
-                OSFramework.Maps.Enum.MarkerType.Marker,
-                JSON.parse(configs)
-            );
+            const _marker =
+                Provider.Maps.Google.Marker.MarkerFactory.MakeMarker(
+                    map,
+                    markerId,
+                    OSFramework.Maps.Enum.MarkerType.Marker,
+                    JSON.parse(configs)
+                );
             markerArr.push(_marker);
             markerMap.set(markerId, map.uniqueId);
             map.addMarker(_marker);

--- a/src/OutSystems/Maps/MapAPI/ShapeManager.Events.ts
+++ b/src/OutSystems/Maps/MapAPI/ShapeManager.Events.ts
@@ -27,7 +27,9 @@ namespace OutSystems.Maps.MapAPI.ShapeManager.Events {
      * @export
      * @param {string} shape Shape that is ready for events
      */
-    export function CheckPendingEvents(shape: OSFramework.Maps.Shape.IShape): void {
+    export function CheckPendingEvents(
+        shape: OSFramework.Maps.Shape.IShape
+    ): void {
         // For each key of the pendingEvents check if the shape has the key as a widgetId or uniqueId and add the new handler
         for (const key of _pendingEvents.keys()) {
             if (shape.equalsToID(key)) {
@@ -57,7 +59,8 @@ namespace OutSystems.Maps.MapAPI.ShapeManager.Events {
         if (lookUpDOM && !_eventsToShapeId.has(eventUniqueId)) {
             const eventElement =
                 OSFramework.Maps.Helper.GetElementByUniqueId(eventUniqueId);
-            const shapeId = OSFramework.Maps.Helper.GetClosestShapeId(eventElement);
+            const shapeId =
+                OSFramework.Maps.Helper.GetClosestShapeId(eventElement);
             _eventsToShapeId.set(eventUniqueId, shapeId);
         }
 
@@ -162,7 +165,9 @@ namespace OutSystems.Maps.MapAPI.ShapeManager.Events {
 /// Overrides for the old namespace - calls the new one, lets users know this is no longer in use
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace MapAPI.ShapeManager.Events {
-    export function CheckPendingEvents(shape: OSFramework.Maps.Shape.IShape): void {
+    export function CheckPendingEvents(
+        shape: OSFramework.Maps.Shape.IShape
+    ): void {
         OSFramework.Maps.Helper.LogWarningMessage(
             `${OSFramework.Maps.Helper.warningMessage} 'OutSystems.Maps.MapAPI.Auxiliary.OutSystems.Maps.MapAPI.ShapeManager.Events.CheckPendingEvents()'`
         );

--- a/src/OutSystems/Maps/MapAPI/ShapeManager.ts
+++ b/src/OutSystems/Maps/MapAPI/ShapeManager.ts
@@ -63,9 +63,12 @@ namespace OutSystems.Maps.MapAPI.ShapeManager {
      * @param shapeId Id of the Shape
      */
     export function GetCircle(shapeId: string): string {
-        const shape = GetShapeById(shapeId) as OSFramework.Maps.Shape.IShapeCircle;
+        const shape = GetShapeById(
+            shapeId
+        ) as OSFramework.Maps.Shape.IShapeCircle;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const properties = new OSFramework.Maps.OSStructures.API.CircleProperties();
+        const properties =
+            new OSFramework.Maps.OSStructures.API.CircleProperties();
         if (shape.type === OSFramework.Maps.Enum.ShapeType.Circle) {
             properties.Center = {
                 Lat: shape.providerCenter.lat,

--- a/src/OutSystems/Maps/PlacesAPI/SearchPlacesManager.ts
+++ b/src/OutSystems/Maps/PlacesAPI/SearchPlacesManager.ts
@@ -4,7 +4,8 @@ namespace OutSystems.Maps.PlacesAPI.SearchPlacesManager {
         string,
         OSFramework.Maps.SearchPlaces.ISearchPlaces
     >(); //searchPlaces.uniqueId -> SearchPlaces obj
-    let activeSearchPlaces: OSFramework.Maps.SearchPlaces.ISearchPlaces = undefined;
+    let activeSearchPlaces: OSFramework.Maps.SearchPlaces.ISearchPlaces =
+        undefined;
 
     /**
      * Function that will change the property value of a given SearchPlaces.

--- a/src/Providers/Maps/Google/Configuration/MarkerClusterer/MarkerClustererConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/MarkerClusterer/MarkerClustererConfig.ts
@@ -24,7 +24,8 @@ namespace Provider.Maps.Google.Configuration.MarkerClusterer {
                 maxZoom: this.markerClustererMaxZoom || 2,
                 minClusterSize: this.markerClustererMinClusterSize,
                 zoomOnClick: this.markerClustererZoomOnClick,
-                clusterClass: OSFramework.Maps.Helper.Constants.clusterIconCSSClass,
+                clusterClass:
+                    OSFramework.Maps.Helper.Constants.clusterIconCSSClass,
                 styles: ClustererStyle
             };
 

--- a/src/Providers/Maps/Google/DrawingTools/AbstractProviderTool.ts
+++ b/src/Providers/Maps/Google/DrawingTools/AbstractProviderTool.ts
@@ -87,7 +87,8 @@ namespace Provider.Maps.Google.DrawingTools {
 
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
         public changeProperty(propertyName: string, value: any): void {
-            const propValue = OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
+            const propValue =
+                OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
             super.changeProperty(propertyName, value);
             if (this.drawingTools.isReady) {
                 switch (propValue) {

--- a/src/Providers/Maps/Google/DrawingTools/DrawMarker.ts
+++ b/src/Providers/Maps/Google/DrawingTools/DrawMarker.ts
@@ -24,7 +24,9 @@ namespace Provider.Maps.Google.DrawingTools {
             );
         }
 
-        private _setOnChangeEvent(_marker: OSFramework.Maps.Marker.IMarker): void {
+        private _setOnChangeEvent(
+            _marker: OSFramework.Maps.Marker.IMarker
+        ): void {
             _marker.markerEvents.addHandler(
                 // changing the marker location is only available via the drag-and-drop, so the solution passes by adding the dragend event listener as the marker's OnChanged event
                 'dragend' as OSFramework.Maps.Event.Marker.MarkerEventType,
@@ -111,7 +113,8 @@ namespace Provider.Maps.Google.DrawingTools {
 
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
         public changeProperty(propertyName: string, value: any): void {
-            const propValue = OSFramework.Maps.Enum.OS_Config_Marker[propertyName];
+            const propValue =
+                OSFramework.Maps.Enum.OS_Config_Marker[propertyName];
             super.changeProperty(propertyName, value);
             if (this.drawingTools.isReady) {
                 switch (propValue) {

--- a/src/Providers/Maps/Google/Features/Center.ts
+++ b/src/Providers/Maps/Google/Features/Center.ts
@@ -1,7 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace Provider.Maps.Google.Feature {
     export class Center
-        implements OSFramework.Maps.Feature.ICenter, OSFramework.Maps.Interface.IBuilder
+        implements
+            OSFramework.Maps.Feature.ICenter,
+            OSFramework.Maps.Interface.IBuilder
     {
         /** Current center position of the Map that changes whenever a marker is added or by enabling the Autofit on Zoom feature */
         private _currentCenter: OSFramework.Maps.OSStructures.OSMap.Coordinates;

--- a/src/Providers/Maps/Google/Features/Directions.ts
+++ b/src/Providers/Maps/Google/Features/Directions.ts
@@ -106,7 +106,8 @@ namespace Provider.Maps.Google.Feature {
                 };
             } else {
                 return {
-                    code: OSFramework.Maps.Enum.ErrorCodes.API_FailedRemoveDirections
+                    code: OSFramework.Maps.Enum.ErrorCodes
+                        .API_FailedRemoveDirections
                 };
             }
         }

--- a/src/Providers/Maps/Google/Features/FeatureBuilder.ts
+++ b/src/Providers/Maps/Google/Features/FeatureBuilder.ts
@@ -88,7 +88,9 @@ namespace Provider.Maps.Google.Feature {
             this._features.trafficLayer = this._makeItem(TrafficLayer, enable);
             return this;
         }
-        private _makeZoom(level: OSFramework.Maps.Enum.OSMap.Zoom): FeatureBuilder {
+        private _makeZoom(
+            level: OSFramework.Maps.Enum.OSMap.Zoom
+        ): FeatureBuilder {
             this._features.zoom = this._makeItem(Zoom, level);
             return this;
         }

--- a/src/Providers/Maps/Google/Features/Offset.ts
+++ b/src/Providers/Maps/Google/Features/Offset.ts
@@ -1,7 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace Provider.Maps.Google.Feature {
     export class Offset
-        implements OSFramework.Maps.Feature.IOffset, OSFramework.Maps.Interface.IBuilder
+        implements
+            OSFramework.Maps.Feature.IOffset,
+            OSFramework.Maps.Interface.IBuilder
     {
         private _map: OSMap.IMapGoogle;
         /** Current offset of the Map */
@@ -22,7 +24,9 @@ namespace Provider.Maps.Google.Feature {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         public build(): void {}
 
-        public setOffset(value: OSFramework.Maps.OSStructures.OSMap.Offset): void {
+        public setOffset(
+            value: OSFramework.Maps.OSStructures.OSMap.Offset
+        ): void {
             this._offset = {
                 offsetX: value.offsetX || 0,
                 offsetY: value.offsetY || 0

--- a/src/Providers/Maps/Google/Helper/Conversions.ts
+++ b/src/Providers/Maps/Google/Helper/Conversions.ts
@@ -12,9 +12,9 @@ namespace Provider.Maps.Google.Helper.Conversions {
         apiKey: string
     ): Promise<OSFramework.Maps.OSStructures.OSMap.Coordinates> {
         // Encodes a location string into a valid format
-        location = encodeURIComponent(location);
+        const encoded_location = encodeURIComponent(location);
         return fetch(
-            `${OSFramework.Maps.Helper.Constants.googleMapsApiGeocode}?address=${location}&key=${apiKey}`
+            `${OSFramework.Maps.Helper.Constants.googleMapsApiGeocode}?address=${encoded_location}&key=${apiKey}`
         )
             .then((response) => {
                 if (response.ok) {
@@ -25,6 +25,9 @@ namespace Provider.Maps.Google.Helper.Conversions {
             })
             .then((json) => {
                 if (json.results.length === 0) {
+                    console.warn(
+                        `No results have been found for address "${location}".`
+                    );
                     throw new Error(
                         json.error_message ?? 'No results have been found.'
                     );


### PR DESCRIPTION
This PR is for show a warning when the location given to a marker returns zero results from Geocode API.

### What was happening
* The marker was not appearing in some cases where the location given was not a valid address

### What was done
* Added a console warning when zero results return from Geocode API.
* Changed the markers' location in samples.

### Test Steps
1. Change the marker location to "OutSystems US". The console should display a warning.
2. Change the marker location to "55 Thomson Pl 2nd floor, Boston, MA 02210, United States". The marker should appear.
3. Change the marker location to "42.351639, -71.046770". The marker should appear.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [x] requires new sample page in OutSystems (if so, provide a module with changes)

