### PR TITLE
ROU-3820v2 - [OSMaps][Leaflet] - Map Event On Zoom Changed is not returning the coordinates 

### DIFF
--- a/src/Providers/Maps/Leaflet/Marker/Marker.ts
+++ b/src/Providers/Maps/Leaflet/Marker/Marker.ts
@@ -229,7 +229,7 @@ namespace Provider.Maps.Leaflet.Marker {
                                     eventName,
                                     // Coords
                                     e !== undefined &&
-                                        e.target.getLatLng() !== undefined
+                                        e.target.getLatLng !== undefined
                                         ? JSON.stringify({
                                               Lat: e.target.getLatLng().lat,
                                               Lng: e.target.getLatLng().lng

--- a/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
@@ -81,7 +81,7 @@ namespace Provider.Maps.Leaflet.OSMap {
                                         .ProviderEvent,
                                     this,
                                     eventName,
-                                    e && e.target.getLatLng() !== undefined
+                                    e && e.target.getLatLng !== undefined
                                         ? JSON.stringify({
                                               Lat: e.target.getLatLng().lat,
                                               Lng: e.target.getLatLng().lng

--- a/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
@@ -81,10 +81,10 @@ namespace Provider.Maps.Leaflet.OSMap {
                                         .ProviderEvent,
                                     this,
                                     eventName,
-                                    e && e.target.getLatLng !== undefined
+                                    e && e.latlng !== undefined
                                         ? JSON.stringify({
-                                              Lat: e.target.getLatLng().lat,
-                                              Lng: e.target.getLatLng().lng
+                                              Lat: e.latlng.lat,
+                                              Lng: e.latlng.lng
                                           })
                                         : undefined
                                 );


### PR DESCRIPTION
This PR is for fixing an issue related with the map event.

### What was happening
* The map events were not returning coordinates when were supposed to.  

### What was done
* Change the validation path.

### Test Steps
1. Add a map event like click, rightclick or doubleClick;
2. Check if the event is returning coordinates;


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

