### PR TITLE
ROU-4001 - [OSMaps] - Marker icon size not working properly when marker is built

### DIFF
--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -82,7 +82,6 @@ namespace Provider.Maps.Google.Marker {
                     OSFramework.Maps.Enum.ErrorCodes.LIB_FailedGeocodingMarker,
                     `Location of the Marker can't be empty.`
                 );
-                return;
             } else {
                 // Let's return a promise that will be resolved or rejected according to the result
                 return new Promise((resolve, reject) => {
@@ -201,6 +200,9 @@ namespace Provider.Maps.Google.Marker {
                             map: this.map.provider
                         });
 
+                        // Call this method so icon respects the sizes that are on config
+                        this._setIconSize();
+
                         // We can only set the events on the provider after its creation
                         this._setMarkerEvents();
 
@@ -255,13 +257,11 @@ namespace Provider.Maps.Google.Marker {
                     case OSFramework.Maps.Enum.OS_Config_Marker.allowDrag:
                         return this._provider.setDraggable(value);
                     case OSFramework.Maps.Enum.OS_Config_Marker.iconHeight:
+                    case OSFramework.Maps.Enum.OS_Config_Marker.iconWidth:
                         this._setIconSize();
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.iconUrl:
                         this._setIcon(value);
-                        return;
-                    case OSFramework.Maps.Enum.OS_Config_Marker.iconWidth:
-                        this._setIconSize();
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.label:
                         return this._provider.setLabel(value);


### PR DESCRIPTION
This PR is for fixing a issue related to the initial attributes of the marker;

### What was happening
* The marker was not respecting the width and height on the build method, those were just used on the change property

### What was done
* call _setIconSize() on the build;

### Test Steps
1. Add an icon with an image url and IconSize filled with a default value
2. Add two inputs to change the width and height
3. Check if the marker appears with the correct size
4. Change the variables using the inputs
5. Check if the marker is updated according to the new values

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

