### PR TITLE
ROU-4222: DrawCircle AddOn does not pass coordinates when editing a shape

### DIFF
--- a/src/OSFramework/Maps/Event/DrawingTools/DrawingToolsProviderEvent.ts
+++ b/src/OSFramework/Maps/Event/DrawingTools/DrawingToolsProviderEvent.ts
@@ -13,8 +13,9 @@ namespace OSFramework.Maps.Event.DrawingTools {
          * Method that will trigger the event with the correct parameters.
          * @param mapId Id of the Map that is raising the event
          * @param drawingToolsId Id of the DrawingTools that is raising the event
-         * @param eventName Name of the event that got raised
          * @param isNewElement IsNewShape/IsNewMarker (empty if the provider event is not handled by the element creator or changer)
+         * @param coordinates string contaning the shape coordinates
+         * @param location string contaning the shape coordinates and other properties as circle radius
          */
         public trigger(
             // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/OSFramework/Maps/Event/DrawingTools/DrawingToolsProviderEvent.ts
+++ b/src/OSFramework/Maps/Event/DrawingTools/DrawingToolsProviderEvent.ts
@@ -20,7 +20,6 @@ namespace OSFramework.Maps.Event.DrawingTools {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             mapId: string,
             drawingToolsId: string,
-            eventName: string,
             isNewElement: boolean,
             coordinates:
                 | OSStructures.OSMap.Coordinates
@@ -34,7 +33,6 @@ namespace OSFramework.Maps.Event.DrawingTools {
                         h,
                         mapId,
                         drawingToolsId,
-                        eventName,
                         isNewElement,
                         coordinates,
                         location

--- a/src/OSFramework/Maps/Event/Shape/ShapeProviderEvent.ts
+++ b/src/OSFramework/Maps/Event/Shape/ShapeProviderEvent.ts
@@ -14,6 +14,7 @@ namespace OSFramework.Maps.Event.Shape {
          * @param mapId Id of the Map that is raising the event
          * @param shapeId Id of the Shape that is raising the event
          * @param eventName Name of the event that got raised
+         * @param args Event properties as coordinates and location
          */
         public trigger(
             // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/OSFramework/Maps/Event/Shape/ShapeProviderEvent.ts
+++ b/src/OSFramework/Maps/Event/Shape/ShapeProviderEvent.ts
@@ -21,7 +21,7 @@ namespace OSFramework.Maps.Event.Shape {
             mapId: string,
             shapeId: string,
             eventName: string,
-            args: any
+            args: OSFramework.Maps.OSStructures.OSMap.OSShapeCoordinates
         ): void {
             this.handlers
                 .slice(0)

--- a/src/OSFramework/Maps/Event/Shape/ShapeProviderEvent.ts
+++ b/src/OSFramework/Maps/Event/Shape/ShapeProviderEvent.ts
@@ -14,14 +14,14 @@ namespace OSFramework.Maps.Event.Shape {
          * @param mapId Id of the Map that is raising the event
          * @param shapeId Id of the Shape that is raising the event
          * @param eventName Name of the event that got raised
-         * @param args Event properties as coordinates and location
+         * @param coords Event properties as coordinates and location
          */
         public trigger(
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             mapId: string,
             shapeId: string,
             eventName: string,
-            args: OSFramework.Maps.OSStructures.OSMap.OSShapeCoordinates
+            coords: OSFramework.Maps.OSStructures.OSMap.OSShapeCoordinates
         ): void {
             this.handlers
                 .slice(0)
@@ -31,7 +31,7 @@ namespace OSFramework.Maps.Event.Shape {
                         mapId,
                         shapeId,
                         eventName,
-                        args
+                        coords
                     )
                 );
         }

--- a/src/OSFramework/Maps/Event/Shape/ShapeProviderEvent.ts
+++ b/src/OSFramework/Maps/Event/Shape/ShapeProviderEvent.ts
@@ -21,7 +21,7 @@ namespace OSFramework.Maps.Event.Shape {
             mapId: string,
             shapeId: string,
             eventName: string,
-            args
+            args: any
         ): void {
             this.handlers
                 .slice(0)

--- a/src/OSFramework/Maps/Event/Shape/ShapeProviderEvent.ts
+++ b/src/OSFramework/Maps/Event/Shape/ShapeProviderEvent.ts
@@ -19,12 +19,19 @@ namespace OSFramework.Maps.Event.Shape {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             mapId: string,
             shapeId: string,
-            eventName: string
+            eventName: string,
+            args
         ): void {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.CallbackAsyncInvocation(h, mapId, shapeId, eventName)
+                    Helper.CallbackAsyncInvocation(
+                        h,
+                        mapId,
+                        shapeId,
+                        eventName,
+                        args
+                    )
                 );
         }
     }

--- a/src/OSFramework/Maps/OSStructures/OSMap.Coordinates.ts
+++ b/src/OSFramework/Maps/OSStructures/OSMap.Coordinates.ts
@@ -17,4 +17,27 @@ namespace OSFramework.Maps.OSStructures.OSMap {
             this.Lng = lng;
         }
     }
+
+    export type PolylineCoordinates = {
+        coordinates: Array<OSCoordinates>;
+        location: Array<string>;
+    };
+
+    export type CircleCoordinates = {
+        coordinates: OSCoordinates;
+        location: {
+            location: string;
+            radius: number;
+        };
+    };
+
+    export type RectangleCoordinates = {
+        coordinates: Bounds;
+        location: Bounds;
+    };
+
+    export type OSShapeCoordinates =
+        | PolylineCoordinates // Polyline and Polygon type
+        | CircleCoordinates
+        | RectangleCoordinates;
 }

--- a/src/OSFramework/Maps/Shape/AbstractShape.ts
+++ b/src/OSFramework/Maps/Shape/AbstractShape.ts
@@ -120,8 +120,21 @@ namespace OSFramework.Maps.Shape {
             return this.shapeProviderEvents.indexOf(eventName) !== -1;
         }
 
+        protected triggerShapeChangedEvent() {
+            const shapeLocation = this.getShapeCoordinates();
+
+            this.shapeEvents.trigger(
+                // EventType
+                OSFramework.Maps.Event.Shape.ShapeEventType.ProviderEvent,
+                // EventName
+                OSFramework.Maps.Helper.Constants.shapeChangedEvent,
+                shapeLocation
+            );
+        }
+
         protected abstract get invalidShapeLocationErrorCode(): Enum.ErrorCodes;
 
+        protected abstract getShapeCoordinates(): OSFramework.Maps.OSStructures.OSMap.OSShapeCoordinates;
         public abstract refreshProviderEvents(): void;
         public abstract get shapeProviderEvents(): Array<string>;
         public abstract get shapeTag(): string;

--- a/src/Providers/Maps/Google/DrawingTools/AbstractDrawShape.ts
+++ b/src/Providers/Maps/Google/DrawingTools/AbstractDrawShape.ts
@@ -26,7 +26,7 @@ namespace Provider.Maps.Google.DrawingTools {
                     mapId: string,
                     shapeId: string,
                     eventName: string,
-                    shapeProperties: any
+                    shapeCoordinates: OSFramework.Maps.OSStructures.OSMap.OSShapeCoordinates
                 ) => {
                     this.drawingTools.drawingToolsEvents.trigger(
                         // EventType
@@ -38,9 +38,9 @@ namespace Provider.Maps.Google.DrawingTools {
                         {
                             uniqueId: _shape.uniqueId,
                             isNewElement: false,
-                            location: JSON.stringify(shapeProperties.location),
+                            location: JSON.stringify(shapeCoordinates.location),
                             coordinates: JSON.stringify(
-                                shapeProperties.coordinates
+                                shapeCoordinates.coordinates
                             )
                         }
                     );

--- a/src/Providers/Maps/Google/DrawingTools/AbstractDrawShape.ts
+++ b/src/Providers/Maps/Google/DrawingTools/AbstractDrawShape.ts
@@ -16,6 +16,38 @@ namespace Provider.Maps.Google.DrawingTools {
             super(map, drawingTools, drawingToolsId, type, configs);
         }
 
+        /** Add the onChange event to the new element */
+        private _setOnChangeEvent(_shape: OSFramework.Maps.Shape.IShape): void {
+            _shape.shapeEvents.addHandler(
+                // changing the shape locations or bounds is only available via the drag-and-drop and resize, so the solution passes by adding the shape_changed event listener as the shape's OnChanged event
+                OSFramework.Maps.Helper.Constants
+                    .shapeChangedEvent as OSFramework.Maps.Event.Shape.ShapeEventType,
+                (
+                    mapId: string,
+                    shapeId: string,
+                    eventName: string,
+                    shapeProperties: any
+                ) => {
+                    this.drawingTools.drawingToolsEvents.trigger(
+                        // EventType
+                        OSFramework.Maps.Event.DrawingTools
+                            .DrawingToolsEventType.ProviderEvent,
+                        // EventName
+                        this.completedToolEventName,
+                        // The extra parameters, uniqueId and isNewElement set to false indicating that the element is not new
+                        {
+                            uniqueId: _shape.uniqueId,
+                            isNewElement: false,
+                            location: JSON.stringify(shapeProperties.location),
+                            coordinates: JSON.stringify(
+                                shapeProperties.coordinates
+                            )
+                        }
+                    );
+                }
+            );
+        }
+
         /** Create the new shape element based on the configurations (already contains the locations, the bounds or the center and radius depending on the type of the new shape) */
         protected createShapeElement(
             uniqueId: string,
@@ -31,38 +63,11 @@ namespace Provider.Maps.Google.DrawingTools {
             );
 
             // Add the onChange event to the new element
-            this.setOnChangeEvent(_shape, _shape.config.locations);
+            this._setOnChangeEvent(_shape);
             // Add the new element to the map
             this.map.addShape(_shape);
 
             return _shape;
-        }
-
-        /** Add the onChange event to the new element */
-        protected setOnChangeEvent(
-            _shape: OSFramework.Maps.Shape.IShape,
-            locations: string
-        ): void {
-            _shape.shapeEvents.addHandler(
-                // changing the shape locations or bounds is only available via the drag-and-drop and resize, so the solution passes by adding the shape_changed event listener as the shape's OnChanged event
-                OSFramework.Maps.Helper.Constants
-                    .shapeChangedEvent as OSFramework.Maps.Event.Shape.ShapeEventType,
-                () => {
-                    this.drawingTools.drawingToolsEvents.trigger(
-                        // EventType
-                        OSFramework.Maps.Event.DrawingTools
-                            .DrawingToolsEventType.ProviderEvent,
-                        // EventName
-                        this.completedToolEventName,
-                        // The extra parameters, uniqueId and isNewElement set to false indicating that the element is not new
-                        {
-                            uniqueId: _shape.uniqueId,
-                            isNewElement: false,
-                            locations
-                        }
-                    );
-                }
-            );
         }
 
         public build(): void {

--- a/src/Providers/Maps/Google/Shape/AbstractProviderShape.ts
+++ b/src/Providers/Maps/Google/Shape/AbstractProviderShape.ts
@@ -211,13 +211,13 @@ namespace Provider.Maps.Google.Shape {
 
         public abstract get shapeTag(): string;
 
-        protected abstract getShapeProperties(): any;
-
         protected abstract _createProvider(
             locations:
                 | Array<OSFramework.Maps.OSStructures.OSMap.Coordinates>
                 | OSFramework.Maps.OSStructures.OSMap.Coordinates
                 | OSFramework.Maps.OSStructures.OSMap.Bounds
         ): W;
+
+        protected abstract getShapeProperties(): any;
     }
 }

--- a/src/Providers/Maps/Google/Shape/AbstractProviderShape.ts
+++ b/src/Providers/Maps/Google/Shape/AbstractProviderShape.ts
@@ -16,18 +16,6 @@ namespace Provider.Maps.Google.Shape {
             });
         }
 
-        private _triggerShapeChangedEvent() {
-            const shapeProperties = this.getShapeProperties();
-
-            this.shapeEvents.trigger(
-                // EventType
-                OSFramework.Maps.Event.Shape.ShapeEventType.ProviderEvent,
-                // EventName
-                OSFramework.Maps.Helper.Constants.shapeChangedEvent,
-                shapeProperties
-            );
-        }
-
         /** Builds the provider (asynchronously) by receving a set of multiple coordinates (creating a path for the shape) or just one (creating the center of the shape) */
         protected _buildProvider(
             coordinates:
@@ -112,7 +100,7 @@ namespace Provider.Maps.Google.Shape {
                                         }
                                         this._shapeChangedEventTimeout =
                                             setTimeout(
-                                                this._triggerShapeChangedEvent.bind(
+                                                this.triggerShapeChangedEvent.bind(
                                                     this
                                                 ),
                                                 500
@@ -217,7 +205,5 @@ namespace Provider.Maps.Google.Shape {
                 | OSFramework.Maps.OSStructures.OSMap.Coordinates
                 | OSFramework.Maps.OSStructures.OSMap.Bounds
         ): W;
-
-        protected abstract getShapeProperties(): any;
     }
 }

--- a/src/Providers/Maps/Google/Shape/AbstractProviderShape.ts
+++ b/src/Providers/Maps/Google/Shape/AbstractProviderShape.ts
@@ -16,6 +16,18 @@ namespace Provider.Maps.Google.Shape {
             });
         }
 
+        private _triggerShapeChangedEvent() {
+            const shapeProperties = this.getShapeProperties();
+
+            this.shapeEvents.trigger(
+                // EventType
+                OSFramework.Maps.Event.Shape.ShapeEventType.ProviderEvent,
+                // EventName
+                OSFramework.Maps.Helper.Constants.shapeChangedEvent,
+                shapeProperties // retornar apenas location e radius etc
+            );
+        }
+
         /** Builds the provider (asynchronously) by receving a set of multiple coordinates (creating a path for the shape) or just one (creating the center of the shape) */
         protected _buildProvider(
             coordinates:
@@ -100,18 +112,9 @@ namespace Provider.Maps.Google.Shape {
                                         }
                                         this._shapeChangedEventTimeout =
                                             setTimeout(
-                                                () =>
-                                                    this.shapeEvents.trigger(
-                                                        // EventType
-                                                        OSFramework.Maps.Event
-                                                            .Shape
-                                                            .ShapeEventType
-                                                            .ProviderEvent,
-                                                        // EventName
-                                                        OSFramework.Maps.Helper
-                                                            .Constants
-                                                            .shapeChangedEvent
-                                                    ),
+                                                this._triggerShapeChangedEvent.bind(
+                                                    this
+                                                ),
                                                 500
                                             );
                                     }
@@ -207,6 +210,8 @@ namespace Provider.Maps.Google.Shape {
         public abstract get providerObjectListener(): any;
 
         public abstract get shapeTag(): string;
+
+        protected abstract getShapeProperties(): any;
 
         protected abstract _createProvider(
             locations:

--- a/src/Providers/Maps/Google/Shape/AbstractProviderShape.ts
+++ b/src/Providers/Maps/Google/Shape/AbstractProviderShape.ts
@@ -24,7 +24,7 @@ namespace Provider.Maps.Google.Shape {
                 OSFramework.Maps.Event.Shape.ShapeEventType.ProviderEvent,
                 // EventName
                 OSFramework.Maps.Helper.Constants.shapeChangedEvent,
-                shapeProperties // retornar apenas location e radius etc
+                shapeProperties
             );
         }
 

--- a/src/Providers/Maps/Google/Shape/Circle.ts
+++ b/src/Providers/Maps/Google/Shape/Circle.ts
@@ -67,13 +67,7 @@ namespace Provider.Maps.Google.Shape {
                 .CFG_InvalidCircleShapeCenter;
         }
 
-        protected getShapeProperties(): {
-            coordinates: OSFramework.Maps.OSStructures.OSMap.OSCoordinates;
-            location: {
-                location: string;
-                radius: number;
-            };
-        } {
+        protected getShapeCoordinates(): OSFramework.Maps.OSStructures.OSMap.CircleCoordinates {
             return {
                 coordinates: {
                     Lat: this.providerCenter.lat,

--- a/src/Providers/Maps/Google/Shape/Circle.ts
+++ b/src/Providers/Maps/Google/Shape/Circle.ts
@@ -67,6 +67,19 @@ namespace Provider.Maps.Google.Shape {
                 .CFG_InvalidCircleShapeCenter;
         }
 
+        protected getShapeProperties() {
+            return {
+                coordinates: {
+                    Lat: this.providerCenter.lat,
+                    Lng: this.providerCenter.lng
+                },
+                location: {
+                    location: `${this.providerCenter.lat.toString()},${this.providerCenter.lng.toString()}`,
+                    radius: this.providerRadius
+                }
+            };
+        }
+
         public get providerCenter(): OSFramework.Maps.OSStructures.OSMap.Coordinates {
             const center = this.provider.get('center');
             if (center === undefined) {

--- a/src/Providers/Maps/Google/Shape/Circle.ts
+++ b/src/Providers/Maps/Google/Shape/Circle.ts
@@ -67,7 +67,13 @@ namespace Provider.Maps.Google.Shape {
                 .CFG_InvalidCircleShapeCenter;
         }
 
-        protected getShapeProperties() {
+        protected getShapeProperties(): {
+            coordinates: OSFramework.Maps.OSStructures.OSMap.OSCoordinates;
+            location: {
+                location: string;
+                radius: number;
+            };
+        } {
             return {
                 coordinates: {
                     Lat: this.providerCenter.lat,

--- a/src/Providers/Maps/Google/Shape/Polygon.ts
+++ b/src/Providers/Maps/Google/Shape/Polygon.ts
@@ -36,10 +36,7 @@ namespace Provider.Maps.Google.Shape {
             });
         }
 
-        protected getShapeProperties(): {
-            coordinates: Array<OSFramework.Maps.OSStructures.OSMap.OSCoordinates>;
-            location: Array<string>;
-        } {
+        protected getShapeCoordinates(): OSFramework.Maps.OSStructures.OSMap.PolylineCoordinates {
             const locations = this.providerObjectPath
                 .getArray()
                 .map((elm) => `${elm.lat()},${elm.lng()}`);

--- a/src/Providers/Maps/Google/Shape/Polygon.ts
+++ b/src/Providers/Maps/Google/Shape/Polygon.ts
@@ -36,7 +36,10 @@ namespace Provider.Maps.Google.Shape {
             });
         }
 
-        protected getShapeProperties() {
+        protected getShapeProperties(): {
+            coordinates: Array<OSFramework.Maps.OSStructures.OSMap.OSCoordinates>;
+            location: Array<string>;
+        } {
             const locations = (
                 this
                     .providerObjectPath as google.maps.MVCArray<google.maps.LatLng>

--- a/src/Providers/Maps/Google/Shape/Polygon.ts
+++ b/src/Providers/Maps/Google/Shape/Polygon.ts
@@ -40,16 +40,10 @@ namespace Provider.Maps.Google.Shape {
             coordinates: Array<OSFramework.Maps.OSStructures.OSMap.OSCoordinates>;
             location: Array<string>;
         } {
-            const locations = (
-                this
-                    .providerObjectPath as google.maps.MVCArray<google.maps.LatLng>
-            )
+            const locations = this.providerObjectPath
                 .getArray()
                 .map((elm) => `${elm.lat()},${elm.lng()}`);
-            const coordinates = (
-                this
-                    .providerObjectPath as google.maps.MVCArray<google.maps.LatLng>
-            )
+            const coordinates = this.providerObjectPath
                 .getArray()
                 .map((elm) => {
                     return {

--- a/src/Providers/Maps/Google/Shape/Polygon.ts
+++ b/src/Providers/Maps/Google/Shape/Polygon.ts
@@ -36,9 +36,38 @@ namespace Provider.Maps.Google.Shape {
             });
         }
 
+        protected getShapeProperties() {
+            const locations = (
+                this
+                    .providerObjectPath as google.maps.MVCArray<google.maps.LatLng>
+            )
+                .getArray()
+                .map((elm) => `${elm.lat()},${elm.lng()}`);
+            const coordinates = (
+                this
+                    .providerObjectPath as google.maps.MVCArray<google.maps.LatLng>
+            )
+                .getArray()
+                .map((elm) => {
+                    return {
+                        Lat: elm.lat(),
+                        Lng: elm.lng()
+                    };
+                });
+            return {
+                location: locations,
+                coordinates: coordinates
+            };
+        }
+
         protected get invalidShapeLocationErrorCode(): OSFramework.Maps.Enum.ErrorCodes {
             return OSFramework.Maps.Enum.ErrorCodes
                 .CFG_InvalidPolygonShapeLocations;
+        }
+
+        protected get providerObjectPath(): google.maps.MVCArray<google.maps.LatLng> {
+            // We need to get the first position of the Array because here the latLngs are inside an
+            return this.provider.getPath();
         }
 
         public get shapeTag(): string {

--- a/src/Providers/Maps/Google/Shape/Polyline.ts
+++ b/src/Providers/Maps/Google/Shape/Polyline.ts
@@ -34,7 +34,10 @@ namespace Provider.Maps.Google.Shape {
             });
         }
 
-        protected getShapeProperties() {
+        protected getShapeProperties(): {
+            coordinates: Array<OSFramework.Maps.OSStructures.OSMap.OSCoordinates>;
+            location: Array<string>;
+        } {
             const locations = (
                 this
                     .providerObjectPath as google.maps.MVCArray<google.maps.LatLng>

--- a/src/Providers/Maps/Google/Shape/Polyline.ts
+++ b/src/Providers/Maps/Google/Shape/Polyline.ts
@@ -34,10 +34,7 @@ namespace Provider.Maps.Google.Shape {
             });
         }
 
-        protected getShapeProperties(): {
-            coordinates: Array<OSFramework.Maps.OSStructures.OSMap.OSCoordinates>;
-            location: Array<string>;
-        } {
+        protected getShapeCoordinates(): OSFramework.Maps.OSStructures.OSMap.PolylineCoordinates {
             const locations = this.providerObjectPath
                 .getArray()
                 .map((elm) => `${elm.lat()},${elm.lng()}`);

--- a/src/Providers/Maps/Google/Shape/Polyline.ts
+++ b/src/Providers/Maps/Google/Shape/Polyline.ts
@@ -38,16 +38,10 @@ namespace Provider.Maps.Google.Shape {
             coordinates: Array<OSFramework.Maps.OSStructures.OSMap.OSCoordinates>;
             location: Array<string>;
         } {
-            const locations = (
-                this
-                    .providerObjectPath as google.maps.MVCArray<google.maps.LatLng>
-            )
+            const locations = this.providerObjectPath
                 .getArray()
                 .map((elm) => `${elm.lat()},${elm.lng()}`);
-            const coordinates = (
-                this
-                    .providerObjectPath as google.maps.MVCArray<google.maps.LatLng>
-            )
+            const coordinates = this.providerObjectPath
                 .getArray()
                 .map((elm) => {
                     return {

--- a/src/Providers/Maps/Google/Shape/Polyline.ts
+++ b/src/Providers/Maps/Google/Shape/Polyline.ts
@@ -34,9 +34,38 @@ namespace Provider.Maps.Google.Shape {
             });
         }
 
+        protected getShapeProperties() {
+            const locations = (
+                this
+                    .providerObjectPath as google.maps.MVCArray<google.maps.LatLng>
+            )
+                .getArray()
+                .map((elm) => `${elm.lat()},${elm.lng()}`);
+            const coordinates = (
+                this
+                    .providerObjectPath as google.maps.MVCArray<google.maps.LatLng>
+            )
+                .getArray()
+                .map((elm) => {
+                    return {
+                        Lat: elm.lat(),
+                        Lng: elm.lng()
+                    };
+                });
+            return {
+                location: locations,
+                coordinates: coordinates
+            };
+        }
+
         protected get invalidShapeLocationErrorCode(): OSFramework.Maps.Enum.ErrorCodes {
             return OSFramework.Maps.Enum.ErrorCodes
                 .CFG_InvalidPolylineShapeLocations;
+        }
+
+        protected get providerObjectPath(): google.maps.MVCArray<google.maps.LatLng> {
+            // We need to get the first position of the Array because here the latLngs are inside an
+            return this.provider.getPath();
         }
 
         public get shapeTag(): string {

--- a/src/Providers/Maps/Google/Shape/Rectangle.ts
+++ b/src/Providers/Maps/Google/Shape/Rectangle.ts
@@ -105,6 +105,22 @@ namespace Provider.Maps.Google.Shape {
             });
         }
 
+        protected getShapeProperties(): {
+            coordinates: OSFramework.Maps.OSStructures.OSMap.Bounds;
+            location: OSFramework.Maps.OSStructures.OSMap.Bounds;
+        } {
+            const bounds = {
+                north: this.bounds.north,
+                south: this.bounds.south,
+                west: this.bounds.west,
+                east: this.bounds.east
+            };
+            return {
+                location: bounds,
+                coordinates: bounds
+            };
+        }
+
         protected get invalidShapeLocationErrorCode(): OSFramework.Maps.Enum.ErrorCodes {
             return OSFramework.Maps.Enum.ErrorCodes
                 .CFG_InvalidRectangleShapeBounds;
@@ -175,19 +191,6 @@ namespace Provider.Maps.Google.Shape {
                         return;
                 }
             }
-        }
-
-        protected getShapeProperties() {
-            const bounds = {
-                north: this.bounds.north,
-                south: this.bounds.south,
-                west: this.bounds.west,
-                east: this.bounds.east
-            };
-            return {
-                location: bounds,
-                coordinates: bounds
-            };
         }
     }
 }

--- a/src/Providers/Maps/Google/Shape/Rectangle.ts
+++ b/src/Providers/Maps/Google/Shape/Rectangle.ts
@@ -176,5 +176,18 @@ namespace Provider.Maps.Google.Shape {
                 }
             }
         }
+
+        protected getShapeProperties() {
+            const bounds = {
+                north: this.bounds.north,
+                south: this.bounds.south,
+                west: this.bounds.west,
+                east: this.bounds.east
+            };
+            return {
+                location: bounds,
+                coordinates: bounds
+            };
+        }
     }
 }

--- a/src/Providers/Maps/Google/Shape/Rectangle.ts
+++ b/src/Providers/Maps/Google/Shape/Rectangle.ts
@@ -105,10 +105,7 @@ namespace Provider.Maps.Google.Shape {
             });
         }
 
-        protected getShapeProperties(): {
-            coordinates: OSFramework.Maps.OSStructures.OSMap.Bounds;
-            location: OSFramework.Maps.OSStructures.OSMap.Bounds;
-        } {
+        protected getShapeCoordinates(): OSFramework.Maps.OSStructures.OSMap.RectangleCoordinates {
             const bounds = {
                 north: this.bounds.north,
                 south: this.bounds.south,

--- a/src/Providers/Maps/Leaflet/DrawingTools/AbstractDrawShape.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/AbstractDrawShape.ts
@@ -22,7 +22,12 @@ namespace Provider.Maps.Leaflet.DrawingTools {
                 // changing the shape locations or bounds is only available via the drag-and-drop and resize, so the solution passes by adding the shape_changed event listener as the shape's OnChanged event
                 OSFramework.Maps.Helper.Constants
                     .shapeChangedEvent as OSFramework.Maps.Event.Shape.ShapeEventType,
-                () => {
+                (
+                    mapId: string,
+                    shapeId: string,
+                    eventName: string,
+                    shapeProperties: any
+                ) => {
                     this.drawingTools.drawingToolsEvents.trigger(
                         // EventType
                         OSFramework.Maps.Event.DrawingTools
@@ -30,7 +35,14 @@ namespace Provider.Maps.Leaflet.DrawingTools {
                         // EventName
                         this.completedToolEventName,
                         // The extra parameters, uniqueId and isNewElement set to false indicating that the element is not new
-                        { uniqueId: _shape.uniqueId, isNewElement: false }
+                        {
+                            uniqueId: _shape.uniqueId,
+                            isNewElement: false,
+                            location: JSON.stringify(shapeProperties.location),
+                            coordinates: JSON.stringify(
+                                shapeProperties.coordinates
+                            )
+                        }
                     );
                 }
             );

--- a/src/Providers/Maps/Leaflet/DrawingTools/AbstractDrawShape.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/AbstractDrawShape.ts
@@ -26,7 +26,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
                     mapId: string,
                     shapeId: string,
                     eventName: string,
-                    shapeProperties: any
+                    shapeCoordinates: OSFramework.Maps.OSStructures.OSMap.OSShapeCoordinates
                 ) => {
                     this.drawingTools.drawingToolsEvents.trigger(
                         // EventType
@@ -38,9 +38,9 @@ namespace Provider.Maps.Leaflet.DrawingTools {
                         {
                             uniqueId: _shape.uniqueId,
                             isNewElement: false,
-                            location: JSON.stringify(shapeProperties.location),
+                            location: JSON.stringify(shapeCoordinates.location),
                             coordinates: JSON.stringify(
-                                shapeProperties.coordinates
+                                shapeCoordinates.coordinates
                             )
                         }
                     );

--- a/src/Providers/Maps/Leaflet/Shape/AbstractProviderShape.ts
+++ b/src/Providers/Maps/Leaflet/Shape/AbstractProviderShape.ts
@@ -41,18 +41,6 @@ namespace Provider.Maps.Leaflet.Shape {
                 : providerShape.dragging.disable();
         }
 
-        private _triggerShapeChangedEvent() {
-            const shapeProperties = this.getShapeProperties();
-
-            this.shapeEvents.trigger(
-                // EventType
-                OSFramework.Maps.Event.Shape.ShapeEventType.ProviderEvent,
-                // EventName
-                OSFramework.Maps.Helper.Constants.shapeChangedEvent,
-                shapeProperties
-            );
-        }
-
         /** Builds the provider (asynchronously) by receving a set of multiple coordinates (creating a path for the shape) or just one (creating the center of the shape) */
         protected buildProvider(
             coordinates:
@@ -137,7 +125,7 @@ namespace Provider.Maps.Leaflet.Shape {
                                         );
                                     }
                                     this._shapeChangedEventTimeout = setTimeout(
-                                        this._triggerShapeChangedEvent.bind(
+                                        this.triggerShapeChangedEvent.bind(
                                             this
                                         ),
                                         500
@@ -215,6 +203,5 @@ namespace Provider.Maps.Leaflet.Shape {
 
         public abstract get providerEventsList(): Array<string>;
         public abstract get shapeTag(): string;
-        protected abstract getShapeProperties(): any;
     }
 }

--- a/src/Providers/Maps/Leaflet/Shape/AbstractProviderShape.ts
+++ b/src/Providers/Maps/Leaflet/Shape/AbstractProviderShape.ts
@@ -49,7 +49,7 @@ namespace Provider.Maps.Leaflet.Shape {
                 OSFramework.Maps.Event.Shape.ShapeEventType.ProviderEvent,
                 // EventName
                 OSFramework.Maps.Helper.Constants.shapeChangedEvent,
-                shapeProperties // retornar apenas location e radius etc
+                shapeProperties
             );
         }
 
@@ -130,23 +130,19 @@ namespace Provider.Maps.Leaflet.Shape {
                         ) {
                             this._addedEvents.push(eventName);
                             this.providerEventsList.forEach((event) =>
-                                this.provider.addEventListener(
-                                    event,
-                                    (eventData: L.LeafletEvent) => {
-                                        if (this._shapeChangedEventTimeout) {
-                                            clearTimeout(
-                                                this._shapeChangedEventTimeout
-                                            );
-                                        }
-                                        this._shapeChangedEventTimeout =
-                                            setTimeout(
-                                                this._triggerShapeChangedEvent.bind(
-                                                    this
-                                                ),
-                                                500
-                                            );
+                                this.provider.addEventListener(event, () => {
+                                    if (this._shapeChangedEventTimeout) {
+                                        clearTimeout(
+                                            this._shapeChangedEventTimeout
+                                        );
                                     }
-                                )
+                                    this._shapeChangedEventTimeout = setTimeout(
+                                        this._triggerShapeChangedEvent.bind(
+                                            this
+                                        ),
+                                        500
+                                    );
+                                })
                             );
                         } else if (
                             // If the eventName is included inside the ProviderSpecialEvents then add the listener

--- a/src/Providers/Maps/Leaflet/Shape/AbstractProviderShape.ts
+++ b/src/Providers/Maps/Leaflet/Shape/AbstractProviderShape.ts
@@ -41,7 +41,7 @@ namespace Provider.Maps.Leaflet.Shape {
                 : providerShape.dragging.disable();
         }
 
-        private _triggerShapeChangedEvent(shape: any) {
+        private _triggerShapeChangedEvent() {
             const shapeProperties = this.getShapeProperties();
 
             this.shapeEvents.trigger(
@@ -141,8 +141,7 @@ namespace Provider.Maps.Leaflet.Shape {
                                         this._shapeChangedEventTimeout =
                                             setTimeout(
                                                 this._triggerShapeChangedEvent.bind(
-                                                    this,
-                                                    eventData.target
+                                                    this
                                                 ),
                                                 500
                                             );

--- a/src/Providers/Maps/Leaflet/Shape/AbstractProviderShape.ts
+++ b/src/Providers/Maps/Leaflet/Shape/AbstractProviderShape.ts
@@ -41,6 +41,18 @@ namespace Provider.Maps.Leaflet.Shape {
                 : providerShape.dragging.disable();
         }
 
+        private _triggerShapeChangedEvent(shape: any) {
+            const shapeProperties = this.getShapeProperties();
+
+            this.shapeEvents.trigger(
+                // EventType
+                OSFramework.Maps.Event.Shape.ShapeEventType.ProviderEvent,
+                // EventName
+                OSFramework.Maps.Helper.Constants.shapeChangedEvent,
+                shapeProperties // retornar apenas location e radius etc
+            );
+        }
+
         /** Builds the provider (asynchronously) by receving a set of multiple coordinates (creating a path for the shape) or just one (creating the center of the shape) */
         protected buildProvider(
             coordinates:
@@ -118,26 +130,24 @@ namespace Provider.Maps.Leaflet.Shape {
                         ) {
                             this._addedEvents.push(eventName);
                             this.providerEventsList.forEach((event) =>
-                                this.provider.addEventListener(event, () => {
-                                    if (this._shapeChangedEventTimeout) {
-                                        clearTimeout(
-                                            this._shapeChangedEventTimeout
-                                        );
+                                this.provider.addEventListener(
+                                    event,
+                                    (eventData: L.LeafletEvent) => {
+                                        if (this._shapeChangedEventTimeout) {
+                                            clearTimeout(
+                                                this._shapeChangedEventTimeout
+                                            );
+                                        }
+                                        this._shapeChangedEventTimeout =
+                                            setTimeout(
+                                                this._triggerShapeChangedEvent.bind(
+                                                    this,
+                                                    eventData.target
+                                                ),
+                                                500
+                                            );
                                     }
-                                    this._shapeChangedEventTimeout = setTimeout(
-                                        () =>
-                                            this.shapeEvents.trigger(
-                                                // EventType
-                                                OSFramework.Maps.Event.Shape
-                                                    .ShapeEventType
-                                                    .ProviderEvent,
-                                                // EventName
-                                                OSFramework.Maps.Helper
-                                                    .Constants.shapeChangedEvent
-                                            ),
-                                        500
-                                    );
-                                })
+                                )
                             );
                         } else if (
                             // If the eventName is included inside the ProviderSpecialEvents then add the listener
@@ -210,5 +220,6 @@ namespace Provider.Maps.Leaflet.Shape {
 
         public abstract get providerEventsList(): Array<string>;
         public abstract get shapeTag(): string;
+        protected abstract getShapeProperties(): any;
     }
 }

--- a/src/Providers/Maps/Leaflet/Shape/Circle.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Circle.ts
@@ -97,6 +97,25 @@ namespace Provider.Maps.Leaflet.Shape {
             return new L.Circle(center, this.getProviderConfig());
         }
 
+        protected getShapeProperties(): {
+            coordinates: OSFramework.Maps.OSStructures.OSMap.OSCoordinates;
+            location: {
+                location: string;
+                radius: number;
+            };
+        } {
+            return {
+                coordinates: {
+                    Lat: this.providerCenter.lat,
+                    Lng: this.providerCenter.lng
+                },
+                location: {
+                    location: `${this.providerCenter.lat.toString()},${this.providerCenter.lng.toString()}`,
+                    radius: this.providerRadius
+                }
+            };
+        }
+
         public build(): void {
             super.build();
             // First build center coordinates based on the location
@@ -142,19 +161,6 @@ namespace Provider.Maps.Leaflet.Shape {
                         return;
                 }
             }
-        }
-
-        protected getShapeProperties() {
-            return {
-                coordinates: {
-                    Lat: this.providerCenter.lat,
-                    Lng: this.providerCenter.lng
-                },
-                location: {
-                    location: `${this.providerCenter.lat.toString()},${this.providerCenter.lng.toString()}`,
-                    radius: this.providerRadius
-                }
-            };
         }
     }
 }

--- a/src/Providers/Maps/Leaflet/Shape/Circle.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Circle.ts
@@ -97,13 +97,7 @@ namespace Provider.Maps.Leaflet.Shape {
             return new L.Circle(center, this.getProviderConfig());
         }
 
-        protected getShapeProperties(): {
-            coordinates: OSFramework.Maps.OSStructures.OSMap.OSCoordinates;
-            location: {
-                location: string;
-                radius: number;
-            };
-        } {
+        protected getShapeCoordinates(): OSFramework.Maps.OSStructures.OSMap.CircleCoordinates {
             return {
                 coordinates: {
                     Lat: this.providerCenter.lat,

--- a/src/Providers/Maps/Leaflet/Shape/Circle.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Circle.ts
@@ -143,5 +143,18 @@ namespace Provider.Maps.Leaflet.Shape {
                 }
             }
         }
+
+        protected getShapeProperties() {
+            return {
+                coordinates: {
+                    Lat: this.providerCenter.lat,
+                    Lng: this.providerCenter.lng
+                },
+                location: {
+                    location: `${this.providerCenter.lat.toString()},${this.providerCenter.lng.toString()}`,
+                    radius: this.providerRadius
+                }
+            };
+        }
     }
 }

--- a/src/Providers/Maps/Leaflet/Shape/Polygon.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Polygon.ts
@@ -43,5 +43,23 @@ namespace Provider.Maps.Leaflet.Shape {
         ): L.Polygon {
             return new L.Polygon(path, this.getProviderConfig());
         }
+
+        protected getShapeProperties() {
+            const locations = (this.providerObjectPath as Array<L.LatLng>).map(
+                (elm) => `${elm.lat},${elm.lng}`
+            );
+            const coordinates = (
+                this.providerObjectPath as Array<L.LatLng>
+            ).map((elm) => {
+                return {
+                    Lat: elm.lat,
+                    Lng: elm.lng
+                };
+            });
+            return {
+                location: locations,
+                coordinates: coordinates
+            };
+        }
     }
 }

--- a/src/Providers/Maps/Leaflet/Shape/Polygon.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Polygon.ts
@@ -44,10 +44,7 @@ namespace Provider.Maps.Leaflet.Shape {
             return new L.Polygon(path, this.getProviderConfig());
         }
 
-        protected getShapeProperties(): {
-            coordinates: Array<OSFramework.Maps.OSStructures.OSMap.OSCoordinates>;
-            location: Array<string>;
-        } {
+        protected getShapeCoordinates(): OSFramework.Maps.OSStructures.OSMap.PolylineCoordinates {
             const locations = (this.providerObjectPath as Array<L.LatLng>).map(
                 (elm) => `${elm.lat},${elm.lng}`
             );

--- a/src/Providers/Maps/Leaflet/Shape/Polygon.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Polygon.ts
@@ -44,7 +44,10 @@ namespace Provider.Maps.Leaflet.Shape {
             return new L.Polygon(path, this.getProviderConfig());
         }
 
-        protected getShapeProperties() {
+        protected getShapeProperties(): {
+            coordinates: Array<OSFramework.Maps.OSStructures.OSMap.OSCoordinates>;
+            location: Array<string>;
+        } {
             const locations = (this.providerObjectPath as Array<L.LatLng>).map(
                 (elm) => `${elm.lat},${elm.lng}`
             );

--- a/src/Providers/Maps/Leaflet/Shape/Polyline.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Polyline.ts
@@ -41,5 +41,23 @@ namespace Provider.Maps.Leaflet.Shape {
         ): L.Polyline {
             return new L.Polyline(path, this.getProviderConfig());
         }
+
+        protected getShapeProperties() {
+            const locations = (this.providerObjectPath as Array<L.LatLng>).map(
+                (elm) => `${elm.lat},${elm.lng}`
+            );
+            const coordinates = (
+                this.providerObjectPath as Array<L.LatLng>
+            ).map((elm) => {
+                return {
+                    Lat: elm.lat,
+                    Lng: elm.lng
+                };
+            });
+            return {
+                location: locations,
+                coordinates: coordinates
+            };
+        }
     }
 }

--- a/src/Providers/Maps/Leaflet/Shape/Polyline.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Polyline.ts
@@ -42,10 +42,7 @@ namespace Provider.Maps.Leaflet.Shape {
             return new L.Polyline(path, this.getProviderConfig());
         }
 
-        protected getShapeProperties(): {
-            coordinates: Array<OSFramework.Maps.OSStructures.OSMap.OSCoordinates>;
-            location: Array<string>;
-        } {
+        protected getShapeCoordinates(): OSFramework.Maps.OSStructures.OSMap.PolylineCoordinates {
             const locations = (this.providerObjectPath as Array<L.LatLng>).map(
                 (elm) => `${elm.lat},${elm.lng}`
             );

--- a/src/Providers/Maps/Leaflet/Shape/Polyline.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Polyline.ts
@@ -42,7 +42,10 @@ namespace Provider.Maps.Leaflet.Shape {
             return new L.Polyline(path, this.getProviderConfig());
         }
 
-        protected getShapeProperties() {
+        protected getShapeProperties(): {
+            coordinates: Array<OSFramework.Maps.OSStructures.OSMap.OSCoordinates>;
+            location: Array<string>;
+        } {
             const locations = (this.providerObjectPath as Array<L.LatLng>).map(
                 (elm) => `${elm.lat},${elm.lng}`
             );

--- a/src/Providers/Maps/Leaflet/Shape/Rectangle.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Rectangle.ts
@@ -130,6 +130,22 @@ namespace Provider.Maps.Leaflet.Shape {
             });
         }
 
+        protected getShapeProperties(): {
+            coordinates: OSFramework.Maps.OSStructures.OSMap.Bounds;
+            location: OSFramework.Maps.OSStructures.OSMap.Bounds;
+        } {
+            const bounds = {
+                north: this.bounds.north,
+                south: this.bounds.south,
+                west: this.bounds.west,
+                east: this.bounds.east
+            };
+            return {
+                location: bounds,
+                coordinates: bounds
+            };
+        }
+
         public build(): void {
             super.build();
 
@@ -178,19 +194,6 @@ namespace Provider.Maps.Leaflet.Shape {
                         return;
                 }
             }
-        }
-
-        protected getShapeProperties() {
-            const bounds = {
-                north: this.bounds.north,
-                south: this.bounds.south,
-                west: this.bounds.west,
-                east: this.bounds.east
-            };
-            return {
-                location: bounds,
-                coordinates: bounds
-            };
         }
     }
 }

--- a/src/Providers/Maps/Leaflet/Shape/Rectangle.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Rectangle.ts
@@ -179,5 +179,18 @@ namespace Provider.Maps.Leaflet.Shape {
                 }
             }
         }
+
+        protected getShapeProperties() {
+            const bounds = {
+                north: this.bounds.north,
+                south: this.bounds.south,
+                west: this.bounds.west,
+                east: this.bounds.east
+            };
+            return {
+                location: bounds,
+                coordinates: bounds
+            };
+        }
     }
 }

--- a/src/Providers/Maps/Leaflet/Shape/Rectangle.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Rectangle.ts
@@ -130,10 +130,7 @@ namespace Provider.Maps.Leaflet.Shape {
             });
         }
 
-        protected getShapeProperties(): {
-            coordinates: OSFramework.Maps.OSStructures.OSMap.Bounds;
-            location: OSFramework.Maps.OSStructures.OSMap.Bounds;
-        } {
+        protected getShapeCoordinates(): OSFramework.Maps.OSStructures.OSMap.RectangleCoordinates {
             const bounds = {
                 north: this.bounds.north,
                 south: this.bounds.south,


### PR DESCRIPTION
This PR is for fix the updated coordinates not being passed to the OnDrawChange event.

### What was happening
* It didn't exist a method o get the updated shape coordinates.
* The updated coordinates were not being passed as an argument to the ShapeProviderEvent.

### What was done
* Created the getShapeProperties method for all shapes. This method returns the updated shape coordinates.
* In ShapeProviderEvent: Added an argument to trigger method to pass the updated shape coordinates.
* In AbstractDrawShape: Modified the _setOnChangeEvent method to pass the updated shape coordinates when triggering the DrawingToolsEvent.
* In AbstractProviderEvent: 
     * Created the _triggerShapeChangedEvent method that get the updated shape coordinates and trigger the Shape event. 
     * In the _buildProvider method, passed the _triggerShapeChangedEvent as the providerObjectListener handler. 

### Test Steps
1. Go to a page with Maps with DrawingTools AddIOns
2. Create a shape
3. Modify the shape
4. Check if the Coordinates and Location parameters of OnDrawingChange event changed accordingly.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

