### PR TITLE
ROU-4283 - [OSMaps] - Leaflet and Google Maps - DrawCircle AddOn does not pass coordinates when editing a shape

### DIFF
--- a/src/Providers/Maps/Google/DrawingTools/DrawMarker.ts
+++ b/src/Providers/Maps/Google/DrawingTools/DrawMarker.ts
@@ -35,7 +35,10 @@ namespace Provider.Maps.Google.DrawingTools {
                     this.triggerOnDrawingChangeEvent(
                         _marker.uniqueId,
                         false,
-                        JSON.stringify(this._latLng),
+                        JSON.stringify({
+                            Lat: _marker.provider.getPosition().lat(),
+                            Lng: _marker.provider.getPosition().lng()
+                        }),
                         _marker.config.location
                     )
             );

--- a/src/Providers/Maps/Leaflet/DrawingTools/DrawMarker.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/DrawMarker.ts
@@ -77,7 +77,10 @@ namespace Provider.Maps.Leaflet.DrawingTools {
                     this.triggerOnDrawingChangeEvent(
                         _marker.uniqueId,
                         false,
-                        JSON.stringify(this.config.iconUrl),
+                        JSON.stringify({
+                            Lat: _marker.provider.getLatLng().lat,
+                            Lng: _marker.provider.getLatLng().lng
+                        }),
                         _marker.config.location
                     )
             );


### PR DESCRIPTION
This PR is for fixing the feedback of drawing change events for markers created via drawing tools. 

### What was happening
* DrawCircle AddOn does not pass coordinates when editing a shape

### What was done
* fix coords sended on the coordinates parameter of triggerOnDrawingChangeEvent;

### Test Steps
1. Create an editable Marker using drawing tools with a OnDrawingChange event;
2. Config event to show the coordinates of the marker on drawing change;
3. Test the creation and the feedback of changing on a screen (GMaps and Leaflet);

1. Add a draggable Marker with onClick event to show the coordinates;
2. Test the feedback of changing the marker on a screen (GMaps and Leaflet);

1. Add a draggable Marker with a MarkerEvent (right click) to show the coordinates;
2. Test the feedback of changing the marker on a screen (GMaps and Leaflet);

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

