### PR TITLE
ROU-4469: Update Map.css

### DIFF
--- a/styles/Map.css
+++ b/styles/Map.css
@@ -35,6 +35,11 @@
     object-fit: cover;
 }
 
+.runtime-staticMap-container-hide {
+    display: none;
+    height: 0;
+}
+
 html[data-uieditorversion^='1'] .map-wrapper .staticMap-image {
     -servicestudio-height: auto;
 }

--- a/styles/Map.css
+++ b/styles/Map.css
@@ -35,6 +35,10 @@
     object-fit: cover;
 }
 
+/*
+* This will be applied to a container that in runtime will only serve 
+* to import a block which brings the map css.
+*/
 .runtime-staticMap-container-hide {
     display: none;
     height: 0;


### PR DESCRIPTION
Added CSS class `.runtime-staticMap-container-hide` into the block Map.css

### What was happening
* To be compliant with Content Security Policy (CSP) requirements, the support for inline styles will be discontinued. Consequently, this code will be impacted and may not function as expected.
It's important to note that this change will only affect those who need to ensure compliance with CSP guidelines.

### What was done
* In order to anticipate impacts, we replaced the only usage of inline style by creating a CSS class to replace it.

### Test Steps
1. Go to `OSMapsAutomation/MapsStatic`
2. Click on “Show Map“
3. Check that the Static Map is working as it was


### Checklist
* [X] tested locally
* [X] documented the code
* [X] clean all warnings and errors of eslint
* [X] requires changes in OutSystems
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

