### PR TITLE
ROU-4375: Add types to events

### DIFF
--- a/src/OSFramework/Maps/DrawingTools/IDrawingToolsEventParams.ts
+++ b/src/OSFramework/Maps/DrawingTools/IDrawingToolsEventParams.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Maps.DrawingTools {
+    export interface IDrawingToolsEventParams {
+        coordinates: string;
+        isNewElement: boolean;
+        location: string | string[];
+        uniqueId: string;
+    }
+}

--- a/src/OSFramework/Maps/Event/FileLayer/FileLayersEventsManager.ts
+++ b/src/OSFramework/Maps/Event/FileLayer/FileLayersEventsManager.ts
@@ -50,8 +50,9 @@ namespace OSFramework.Maps.Event.FileLayer {
          */
         public trigger(
             eventType: FileLayersEventType,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-            ...args: any
+            data?: string,
+            fileLayerEventParams?: Maps.FileLayer.IFileLayerEventParams,
+            ...args: unknown[]
         ): void {
             // Check if the FileLayer has any events associated
             if (this.handlers.has(eventType)) {
@@ -69,8 +70,9 @@ namespace OSFramework.Maps.Event.FileLayer {
                             this._fileLayer.map.widgetId, // Id of Map block that was clicked
                             this._fileLayer.widgetId ||
                                 this._fileLayer.uniqueId, // Id of File Layer block that was clicked
-                            args[0].coordinates, // LatLng from the click event
-                            args[0].featureData // FeatureData from the FileLayer that was clicked
+                            fileLayerEventParams.coordinates, // LatLng from the click event
+                            fileLayerEventParams.featureData, // FeatureData from the FileLayer that was clicked
+                            ...args
                         );
                         break;
                     // If the event is not valid we can fall in the default case of the switch and throw an error

--- a/src/OSFramework/Maps/Event/SearchPlaces/SearchPlacesEventsManager.ts
+++ b/src/OSFramework/Maps/Event/SearchPlaces/SearchPlacesEventsManager.ts
@@ -39,6 +39,7 @@ namespace OSFramework.Maps.Event.SearchPlaces {
                         SearchPlaces.SearchPlacesEventType.OnError,
                         this._searchPlaces,
                         Enum.ErrorCodes.GEN_UnsupportedEventSearchPlaces,
+                        undefined,
                         `${eventType}`
                     );
                     return;

--- a/src/OSFramework/Maps/Event/SearchPlaces/SearchPlacesEventsManager.ts
+++ b/src/OSFramework/Maps/Event/SearchPlaces/SearchPlacesEventsManager.ts
@@ -77,8 +77,8 @@ namespace OSFramework.Maps.Event.SearchPlaces {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             searchPlaces?: OSFramework.Maps.SearchPlaces.ISearchPlaces,
             eventInfo?: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-            ...args: any
+            searchPlacesEventParams?: Maps.SearchPlaces.ISearchPlacesEventParams,
+            ...args: unknown[]
         ): void {
             // Check if the FileLayer has any events associated
             if (this.handlers.has(eventType)) {
@@ -103,20 +103,20 @@ namespace OSFramework.Maps.Event.SearchPlaces {
                         break;
                     case SearchPlacesEventType.OnPlaceSelect:
                         handlerEvent.trigger(
-                            this._searchPlaces, // SearchPlaces Object where the place selection occurred.
-                            this._searchPlaces.widgetId ||
-                                this._searchPlaces.uniqueId, // Id of SearchPlaces block that was clicked
-                            args[0].name, // name of the place selected
-                            args[0].coordinates, // coordinates of the place selected
-                            args[0].address // full address of the place selected
+                            searchPlaces, // SearchPlaces Object where the place selection occurred.
+                            searchPlaces.widgetId || searchPlaces.uniqueId, // Id of SearchPlaces block that was clicked
+                            searchPlacesEventParams.name, // name of the place selected
+                            searchPlacesEventParams.coordinates, // coordinates of the place selected
+                            searchPlacesEventParams.address // full address of the place selected
                         );
                         break;
                     // If the event is not valid we can fall in the default case of the switch and throw an error
                     default:
                         this._searchPlaces.searchPlacesEvents.trigger(
                             SearchPlaces.SearchPlacesEventType.OnError,
-                            this._searchPlaces,
+                            searchPlaces,
                             Enum.ErrorCodes.GEN_UnsupportedEventSearchPlaces,
+                            undefined,
                             `${eventType}`
                         );
                         return;

--- a/src/OSFramework/Maps/FileLayer/IFileLayerEventParams.ts
+++ b/src/OSFramework/Maps/FileLayer/IFileLayerEventParams.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Maps.FileLayer {
+    export interface IFileLayerEventParams {
+        coordinates: string;
+        featureData: string;
+    }
+}

--- a/src/OSFramework/Maps/SearchPlaces/AbstractSearchPlaces.ts
+++ b/src/OSFramework/Maps/SearchPlaces/AbstractSearchPlaces.ts
@@ -82,6 +82,7 @@ namespace OSFramework.Maps.SearchPlaces {
                     Event.SearchPlaces.SearchPlacesEventType.OnError,
                     this,
                     Enum.ErrorCodes.GEN_InvalidChangePropertySearchPlaces,
+                    undefined,
                     `${propertyName}`
                 );
             }

--- a/src/OSFramework/Maps/SearchPlaces/ISearchPlacesEventParams.ts
+++ b/src/OSFramework/Maps/SearchPlaces/ISearchPlacesEventParams.ts
@@ -1,0 +1,8 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Maps.SearchPlaces {
+    export interface ISearchPlacesEventParams {
+        address: string;
+        coordinates: string;
+        name: string;
+    }
+}

--- a/src/Providers/Maps/Google/DrawingTools/AbstractDrawShape.ts
+++ b/src/Providers/Maps/Google/DrawingTools/AbstractDrawShape.ts
@@ -28,13 +28,7 @@ namespace Provider.Maps.Google.DrawingTools {
                     eventName: string,
                     shapeCoordinates: OSFramework.Maps.OSStructures.OSMap.OSShapeCoordinates
                 ) => {
-                    this.drawingTools.drawingToolsEvents.trigger(
-                        // EventType
-                        OSFramework.Maps.Event.DrawingTools
-                            .DrawingToolsEventType.ProviderEvent,
-                        // EventName
-                        this.completedToolEventName,
-                        // The extra parameters, uniqueId and isNewElement set to false indicating that the element is not new
+                    const dtparams: OSFramework.Maps.DrawingTools.IDrawingToolsEventParams =
                         {
                             uniqueId: _shape.uniqueId,
                             isNewElement: false,
@@ -42,7 +36,16 @@ namespace Provider.Maps.Google.DrawingTools {
                             coordinates: JSON.stringify(
                                 shapeCoordinates.coordinates
                             )
-                        }
+                        };
+
+                    this.drawingTools.drawingToolsEvents.trigger(
+                        // EventType
+                        OSFramework.Maps.Event.DrawingTools
+                            .DrawingToolsEventType.ProviderEvent,
+                        // EventName
+                        this.completedToolEventName,
+                        // The extra parameters, uniqueId and isNewElement set to false indicating that the element is not new
+                        dtparams
                     );
                 }
             );

--- a/src/Providers/Maps/Google/DrawingTools/AbstractDrawShape.ts
+++ b/src/Providers/Maps/Google/DrawingTools/AbstractDrawShape.ts
@@ -28,7 +28,7 @@ namespace Provider.Maps.Google.DrawingTools {
                     eventName: string,
                     shapeCoordinates: OSFramework.Maps.OSStructures.OSMap.OSShapeCoordinates
                 ) => {
-                    const dtparams: OSFramework.Maps.DrawingTools.IDrawingToolsEventParams =
+                    const dtParams: OSFramework.Maps.DrawingTools.IDrawingToolsEventParams =
                         {
                             uniqueId: _shape.uniqueId,
                             isNewElement: false,
@@ -45,7 +45,7 @@ namespace Provider.Maps.Google.DrawingTools {
                         // EventName
                         this.completedToolEventName,
                         // The extra parameters, uniqueId and isNewElement set to false indicating that the element is not new
-                        dtparams
+                        dtParams
                     );
                 }
             );

--- a/src/Providers/Maps/Google/FileLayer/FileLayer.ts
+++ b/src/Providers/Maps/Google/FileLayer/FileLayer.ts
@@ -33,10 +33,7 @@ namespace Provider.Maps.Google.FileLayer {
                 this.provider.addListener(
                     'click',
                     (event: google.maps.KmlMouseEvent) => {
-                        this.fileLayerEvents.trigger(
-                            OSFramework.Maps.Event.FileLayer.FileLayersEventType
-                                .OnClick,
-                            // Extra parameters to be passed as arguments on the callback of the OnClick event handler
+                        const flparams: OSFramework.Maps.FileLayer.IFileLayerEventParams =
                             {
                                 // Coordinates from the event that was triggered (by the click)
                                 coordinates: JSON.stringify({
@@ -50,7 +47,13 @@ namespace Provider.Maps.Google.FileLayer {
                                 featureData: JSON.stringify(
                                     event.featureData as google.maps.KmlFeatureData
                                 )
-                            }
+                            };
+                        this.fileLayerEvents.trigger(
+                            OSFramework.Maps.Event.FileLayer.FileLayersEventType
+                                .OnClick,
+                            undefined,
+                            // Extra parameters to be passed as arguments on the callback of the OnClick event handler
+                            flparams
                         );
                     }
                 );

--- a/src/Providers/Maps/Google/FileLayer/FileLayer.ts
+++ b/src/Providers/Maps/Google/FileLayer/FileLayer.ts
@@ -33,7 +33,7 @@ namespace Provider.Maps.Google.FileLayer {
                 this.provider.addListener(
                     'click',
                     (event: google.maps.KmlMouseEvent) => {
-                        const flparams: OSFramework.Maps.FileLayer.IFileLayerEventParams =
+                        const flParams: OSFramework.Maps.FileLayer.IFileLayerEventParams =
                             {
                                 // Coordinates from the event that was triggered (by the click)
                                 coordinates: JSON.stringify({
@@ -53,7 +53,7 @@ namespace Provider.Maps.Google.FileLayer {
                                 .OnClick,
                             undefined,
                             // Extra parameters to be passed as arguments on the callback of the OnClick event handler
-                            flparams
+                            flParams
                         );
                     }
                 );

--- a/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
@@ -179,7 +179,7 @@ namespace Provider.Maps.Google.SearchPlaces {
                     Constants.SearchPlaces.Events.OnPlaceSelect,
                     () => {
                         const place = this._provider.getPlace();
-                        const spparams: OSFramework.Maps.SearchPlaces.ISearchPlacesEventParams =
+                        const spParams: OSFramework.Maps.SearchPlaces.ISearchPlacesEventParams =
                             {
                                 name: place.name,
                                 coordinates: JSON.stringify({
@@ -196,7 +196,7 @@ namespace Provider.Maps.Google.SearchPlaces {
                                 this, // searchPlacesObj
                                 Constants.SearchPlaces.Events.OnPlaceSelect, // event name (eventInfo)
                                 // Extra parameters to be passed as arguments on the callback of the OnPlaceSelect event handler
-                                spparams
+                                spParams
                             );
                     }
                 );

--- a/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
@@ -178,6 +178,16 @@ namespace Provider.Maps.Google.SearchPlaces {
                     Constants.SearchPlaces.Events.OnPlaceSelect,
                     () => {
                         const place = this._provider.getPlace();
+                        const spparams: OSFramework.Maps.SearchPlaces.ISearchPlacesEventParams =
+                            {
+                                name: place.name,
+                                coordinates: JSON.stringify({
+                                    Lat: place.geometry.location.lat(),
+                                    Lng: place.geometry.location.lng()
+                                }),
+                                address: place.formatted_address
+                            };
+
                         place.geometry &&
                             this.searchPlacesEvents.trigger(
                                 OSFramework.Maps.Event.SearchPlaces
@@ -185,14 +195,7 @@ namespace Provider.Maps.Google.SearchPlaces {
                                 this, // searchPlacesObj
                                 Constants.SearchPlaces.Events.OnPlaceSelect, // event name (eventInfo)
                                 // Extra parameters to be passed as arguments on the callback of the OnPlaceSelect event handler
-                                {
-                                    name: place.name,
-                                    coordinates: JSON.stringify({
-                                        Lat: place.geometry.location.lat(),
-                                        Lng: place.geometry.location.lng()
-                                    }),
-                                    address: place.formatted_address
-                                }
+                                spparams
                             );
                     }
                 );

--- a/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
@@ -290,6 +290,7 @@ namespace Provider.Maps.Google.SearchPlaces {
                                         this,
                                         OSFramework.Maps.Enum.ErrorCodes
                                             .CFG_InvalidSearchPlacesSearchArea,
+                                        undefined,
                                         `${error}`
                                     );
                                 });

--- a/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
@@ -115,6 +115,7 @@ namespace Provider.Maps.Google.SearchPlaces {
                                     this,
                                     OSFramework.Maps.Enum.ErrorCodes
                                         .LIB_FailedGeocodingSearchAreaLocations,
+                                    undefined,
                                     `${error}`
                                 );
                             });


### PR DESCRIPTION
This PR is for missing types to the events of the Maps.

### What was happening
* Previously, some of the events, were accessing to the args in a given position to obtain certain values. This made the code harder to maintain and more error prone.

### What was done
* Added 3 new interfaces:
  * IDrawingToolsEventParams
  * IFileLayerEventParams
  * ISearchPlacesEventParams
* Created a new input parameter in the trigger action of:
  * DrawingTools
  * FileLayer
  * SearchPlaces
* Set the interfaces as the type of the invocation of the trigger method

### Checklist
* [x tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

