### PR TITLE
ROU-4631: improvements to the types in the code

### DIFF
--- a/src/OSFramework/Maps/Configuration/AbstractConfiguration.ts
+++ b/src/OSFramework/Maps/Configuration/AbstractConfiguration.ts
@@ -1,18 +1,16 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.Maps.Configuration {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     export abstract class AbstractConfiguration implements IConfiguration {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        constructor(config: any) {
+        constructor(config: unknown) {
+            const _localConfig = config as unknown[];
             let key;
-            for (key in config) {
-                if (config[key] !== undefined) {
-                    this[key] = config[key];
+            for (key in _localConfig) {
+                if (_localConfig[key] !== undefined) {
+                    this[key] = _localConfig[key];
                 }
             }
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public abstract getProviderConfig(): any;
+        public abstract getProviderConfig(): unknown;
     }
 }

--- a/src/OSFramework/Maps/Configuration/IConfiguration.ts
+++ b/src/OSFramework/Maps/Configuration/IConfiguration.ts
@@ -8,7 +8,6 @@ namespace OSFramework.Maps.Configuration {
         /**
          * Method responsible for the translation of configuration from OS to Provider
          */
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        getProviderConfig(): any;
+        getProviderConfig(): unknown;
     }
 }

--- a/src/OSFramework/Maps/Configuration/IConfigurationMarker.ts
+++ b/src/OSFramework/Maps/Configuration/IConfigurationMarker.ts
@@ -5,11 +5,11 @@ namespace OSFramework.Maps.Configuration {
      * Defines the basic structure for Map objects
      */
     export interface IConfigurationMarker extends IConfiguration {
-        allowDrag: boolean;
-        iconHeight: number;
-        iconUrl: string;
-        iconWidth: number;
-        location: string;
-        title: string;
+        allowDrag?: boolean;
+        iconHeight?: number;
+        iconUrl?: string;
+        iconWidth?: number;
+        location?: string;
+        title?: string;
     }
 }

--- a/src/OSFramework/Maps/DrawingTools/AbstractDrawingTools.ts
+++ b/src/OSFramework/Maps/DrawingTools/AbstractDrawingTools.ts
@@ -1,8 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.Maps.DrawingTools {
     export abstract class AbstractDrawingTools<
-        W,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        W extends IDrawingToolsProvider,
         T extends Configuration.IConfigurationDrawingTools
     > implements IDrawingTools
     {
@@ -15,8 +14,7 @@ namespace OSFramework.Maps.DrawingTools {
         private _widgetId: string;
 
         protected _built: boolean;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        protected _createElements: Array<any>;
+        protected _createElements: Array<unknown>;
         protected _drawingToolsEvents: Event.DrawingTools.DrawingToolsEventsManager;
         protected _provider: W;
 
@@ -35,8 +33,7 @@ namespace OSFramework.Maps.DrawingTools {
         public get config(): T {
             return this._config;
         }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public get createdElements(): Array<any> {
+        public get createdElements(): Array<unknown> {
             return this._createElements;
         }
         public get drawingToolsEvents(): Event.DrawingTools.DrawingToolsEventsManager {
@@ -95,8 +92,10 @@ namespace OSFramework.Maps.DrawingTools {
             this._setWidgetId();
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        public changeProperty(propertyName: string, propertyValue: any): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             //Update Shape's config when the property is available
             if (this.config.hasOwnProperty(propertyName)) {
                 this.config[propertyName] = propertyValue;
@@ -113,8 +112,7 @@ namespace OSFramework.Maps.DrawingTools {
         public changeToolProperty(
             toolId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-            propertyValue: any
+            propertyValue: unknown
         ): void {
             const tool = this._tools.get(toolId);
             tool.changeProperty(propertyName, propertyValue);
@@ -131,9 +129,8 @@ namespace OSFramework.Maps.DrawingTools {
             return id === this._uniqueId || id === this.widgetId;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): Configuration.IConfigurationDrawingTools {
-            return this._config.getProviderConfig();
+            return this._config.getProviderConfig() as Configuration.IConfigurationDrawingTools;
         }
 
         public hasTool(toolId: string): boolean {
@@ -169,8 +166,7 @@ namespace OSFramework.Maps.DrawingTools {
             return this.providerEvents.indexOf(eventName) !== -1;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public abstract get providerEvents(): any;
+        public abstract get providerEvents(): Array<string>;
 
         public abstract refreshProviderEvents(): void;
     }

--- a/src/OSFramework/Maps/DrawingTools/AbstractTool.ts
+++ b/src/OSFramework/Maps/DrawingTools/AbstractTool.ts
@@ -74,8 +74,10 @@ namespace OSFramework.Maps.DrawingTools {
             this._setWidgetId();
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        public changeProperty(propertyName: string, propertyValue: any): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             //Update Shape's config when the property is available
             if (this.config.hasOwnProperty(propertyName)) {
                 this.config[propertyName] = propertyValue;
@@ -99,12 +101,10 @@ namespace OSFramework.Maps.DrawingTools {
         }
 
         public getProviderConfig(): T {
-            return this._config.getProviderConfig();
+            return this._config.getProviderConfig() as T;
         }
+        public abstract get options(): unknown;
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public abstract get options(): any;
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public abstract addCompletedEvent(e?: any): void;
+        public abstract addCompletedEvent(e?: unknown): void;
     }
 }

--- a/src/OSFramework/Maps/DrawingTools/Factory.ts
+++ b/src/OSFramework/Maps/DrawingTools/Factory.ts
@@ -4,7 +4,7 @@ namespace OSFramework.Maps.DrawingTools {
         export function MakeDrawingTools(
             map: OSMap.IMap,
             drawingToolsId: string,
-            configs: Configuration.IConfiguration
+            configs: JSON
         ): DrawingTools.IDrawingTools {
             switch (map.providerType) {
                 case Enum.ProviderType.Google:
@@ -31,7 +31,7 @@ namespace OSFramework.Maps.DrawingTools {
             drawingTools: DrawingTools.IDrawingTools,
             toolId: string,
             type: Enum.DrawingToolsTypes,
-            configs: Configuration.IConfiguration
+            configs: JSON
         ): DrawingTools.ITool {
             switch (map.providerType) {
                 case Enum.ProviderType.Google:

--- a/src/OSFramework/Maps/DrawingTools/IDrawingTools.ts
+++ b/src/OSFramework/Maps/DrawingTools/IDrawingTools.ts
@@ -5,25 +5,21 @@ namespace OSFramework.Maps.DrawingTools {
             Interface.ISearchById,
             Interface.IDisposable {
         config: Configuration.IConfigurationDrawingTools; //IConfigurationDrawingTools
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        createdElements: Array<any>;
+        createdElements: Array<unknown>;
         /** Events from the DrawingTools */
         drawingToolsEvents: Event.DrawingTools.DrawingToolsEventsManager;
         isReady: boolean;
         map: OSMap.IMap; //IMap
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        provider: any;
+        provider: IDrawingToolsProvider;
         /** Events from the DrawingTools provider */
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        providerEvents: any;
+        providerEvents: unknown;
         tools: Array<ITool>;
         uniqueId: string;
         widgetId: string;
 
         /** Adds a Tool into the DrawingTools element */
         addTool(tool: ITool): ITool;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        changeProperty(propertyName: string, propertyValue: any): void;
+        changeProperty(propertyName: string, propertyValue: unknown): void;
         /**
          * Change property of a Tool from the DrawingTools by specifying the property name and the new value
          * @param toolId id of the Tool
@@ -33,8 +29,7 @@ namespace OSFramework.Maps.DrawingTools {
         changeToolProperty(
             toolId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void;
         /**
          * Boolean that indicates whether the DrawingTools element has a tool with the same uniqueId or not

--- a/src/OSFramework/Maps/DrawingTools/IDrawingToolsProvider.ts
+++ b/src/OSFramework/Maps/DrawingTools/IDrawingToolsProvider.ts
@@ -1,0 +1,13 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Maps.DrawingTools {
+    export interface IDrawingToolsProvider {
+        addListener?(
+            eventName: string,
+            cb: OSFramework.Maps.Callbacks.Generic
+        ): void;
+        get?(name: string): unknown;
+        getPosition?(): unknown;
+        setDrawingOptions?(options: unknown): void;
+        setOptions?(options: unknown): void;
+    }
+}

--- a/src/OSFramework/Maps/DrawingTools/ITool.ts
+++ b/src/OSFramework/Maps/DrawingTools/ITool.ts
@@ -8,8 +8,7 @@ namespace OSFramework.Maps.DrawingTools {
         drawingTools: IDrawingTools;
         isReady: boolean;
         map: OSMap.IMap; //IMap
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        options: any;
+        options: unknown;
         type: string;
         uniqueId: string;
         widgetId: string;
@@ -19,9 +18,7 @@ namespace OSFramework.Maps.DrawingTools {
          * The new handlers will create the shape/markers elements and remove the overlay created by the drawing tool on the map
          * @param e is only used by the leaflet implementation, is used to access the configs info on the creation of a new shape/marker
          */
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        addCompletedEvent(e?: any): void;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        changeProperty(propertyName: string, propertyValue: any): void;
+        addCompletedEvent(e?: unknown): void;
+        changeProperty(propertyName: string, propertyValue: unknown): void;
     }
 }

--- a/src/OSFramework/Maps/Event/AbstractEvent.ts
+++ b/src/OSFramework/Maps/Event/AbstractEvent.ts
@@ -1,10 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.Maps.Event {
-    type Handler = {
-        eventHandler: Callbacks.Generic;
-        uniqueId: string; //Event unique identifier
-    };
-
     /**
      * Abstract class that will be responsible for the basic behaviours of a link, namely storing the callbacks.
      *
@@ -16,9 +11,9 @@ namespace OSFramework.Maps.Event {
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     export abstract class AbstractEvent<T> implements IEvent<T> {
-        private _handlers: Handler[] = [];
+        private _handlers: IHandler[] = [];
 
-        protected get handlers(): Handler[] {
+        protected get handlers(): IHandler[] {
             return this._handlers;
         }
 
@@ -46,12 +41,16 @@ namespace OSFramework.Maps.Event {
             }
         }
 
-        // eslint-disable-next-line  @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types
-        public trigger(data?: T, ...args): void {
+        // eslint-disable-next-line  @typescript-eslint/no-unused-vars
+        public trigger(data?: T, ...args: unknown[]): void {
             this._handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.CallbackAsyncInvocation(h.eventHandler, data)
+                    Helper.CallbackAsyncInvocation(
+                        h.eventHandler,
+                        data,
+                        ...args
+                    )
                 );
         }
     }

--- a/src/OSFramework/Maps/Event/AbstractEventsManager.ts
+++ b/src/OSFramework/Maps/Event/AbstractEventsManager.ts
@@ -57,10 +57,9 @@ namespace OSFramework.Maps.Event {
             }
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types
-        public trigger(eventType: ET, data?: D, ...args): void {
+        public trigger(eventType: ET, data?: D, ...args: unknown[]): void {
             if (this._handlers.has(eventType)) {
-                this._handlers.get(eventType).trigger(data);
+                this._handlers.get(eventType).trigger(data, ...args);
             }
         }
 

--- a/src/OSFramework/Maps/Event/DrawingTools/AbstractDrawingToolsEvent.ts
+++ b/src/OSFramework/Maps/Event/DrawingTools/AbstractDrawingToolsEvent.ts
@@ -14,14 +14,13 @@ namespace OSFramework.Maps.Event.DrawingTools {
         public trigger(
             mapId: string,
             drawingToolsId: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            ...args: any
+            ...args: unknown[]
         ): void {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
                     Helper.CallbackAsyncInvocation(
-                        h,
+                        h.eventHandler,
                         mapId,
                         drawingToolsId,
                         ...args

--- a/src/OSFramework/Maps/Event/DrawingTools/DrawingToolsEventsManager.ts
+++ b/src/OSFramework/Maps/Event/DrawingTools/DrawingToolsEventsManager.ts
@@ -55,10 +55,9 @@ namespace OSFramework.Maps.Event.DrawingTools {
          */
         public trigger(
             eventType: DrawingToolsEventType,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             eventInfo?: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-            ...args: any
+            eventParams?: Maps.DrawingTools.IDrawingToolsEventParams,
+            ...args: unknown[]
         ): void {
             // Let's first check if the DrawingTools has any events associated
             // If the event type is ProviderEvent than we need to get the handlers for the eventInfo -> name of the event
@@ -75,7 +74,8 @@ namespace OSFramework.Maps.Event.DrawingTools {
                         handlerEvent.trigger(
                             this._drawingTools.map.widgetId, // Id of Map block that was initialized
                             this._drawingTools.widgetId ||
-                                this._drawingTools.uniqueId // Id of DrawingTools block that was initialized
+                                this._drawingTools.uniqueId, // Id of DrawingTools block that was initialized
+                            ...args
                         );
                         break;
                     case DrawingToolsEventType.ProviderEvent:
@@ -90,13 +90,14 @@ namespace OSFramework.Maps.Event.DrawingTools {
                             );
                             handler.trigger(
                                 this._drawingTools.map.widgetId, // Id of Map block that triggered the event
-                                args[0].uniqueId ||
+                                eventParams.uniqueId ||
                                     this._drawingTools.widgetId ||
                                     this._drawingTools.uniqueId, // Id of marker/shape block (once created by the DrawingTools) that triggered the event
                                 // eventInfo, // Name of the event that got triggered
-                                args[0].isNewElement, // IsNewShape/IsNewMarker default is true
-                                args[0].coordinates, // coordinates in lat/lng structure
-                                args[0].location // location in string, as the shape block accepts coords and addresses
+                                eventParams.isNewElement, // IsNewShape/IsNewMarker default is true
+                                eventParams.coordinates, // coordinates in lat/lng structure
+                                eventParams.location, // location in string, as the shape block accepts coords and addresses
+                                ...args
                             );
                             break;
                         }

--- a/src/OSFramework/Maps/Event/DrawingTools/DrawingToolsProviderEvent.ts
+++ b/src/OSFramework/Maps/Event/DrawingTools/DrawingToolsProviderEvent.ts
@@ -31,7 +31,7 @@ namespace OSFramework.Maps.Event.DrawingTools {
                 .slice(0)
                 .forEach((h) =>
                     Helper.CallbackAsyncInvocation(
-                        h,
+                        h.eventHandler,
                         mapId,
                         drawingToolsId,
                         isNewElement,

--- a/src/OSFramework/Maps/Event/FileLayer/AbstractFileLayersEvent.ts
+++ b/src/OSFramework/Maps/Event/FileLayer/AbstractFileLayersEvent.ts
@@ -8,20 +8,17 @@ namespace OSFramework.Maps.Event.FileLayer {
      * @class AbstractShapeEvent
      * @extends {AbstractEvent<string>}
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     export abstract class AbstractFileLayersEvent extends AbstractEvent<string> {
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
         public trigger(
             mapId: string,
             fileLayerId: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            ...args: any
+            ...args: unknown[]
         ): void {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
                     Helper.CallbackAsyncInvocation(
-                        h,
+                        h.eventHandler,
                         mapId,
                         fileLayerId,
                         ...args

--- a/src/OSFramework/Maps/Event/IEvent.ts
+++ b/src/OSFramework/Maps/Event/IEvent.ts
@@ -9,10 +9,12 @@ namespace OSFramework.Maps.Event {
      * @template D this will the type of Data to be passed, by default to the handlers.
      */
     export interface IEvent<D> {
-        addHandler(handler: OSFramework.Maps.Callbacks.Generic, ...args): void;
+        addHandler(
+            handler: OSFramework.Maps.Callbacks.Generic,
+            ...args: unknown[]
+        ): void;
         hasHandlers(): boolean;
         removeHandler(handler: OSFramework.Maps.Callbacks.Generic): void;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        trigger(data: D, ...args): any;
+        trigger(data: D, ...args: unknown[]): unknown;
     }
 }

--- a/src/OSFramework/Maps/Event/IHandler.ts
+++ b/src/OSFramework/Maps/Event/IHandler.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Maps.Event {
+    export interface IHandler {
+        eventHandler: Callbacks.Generic;
+        uniqueId: string;
+    }
+}

--- a/src/OSFramework/Maps/Event/Marker/AbstractMarkerEvent.ts
+++ b/src/OSFramework/Maps/Event/Marker/AbstractMarkerEvent.ts
@@ -14,13 +14,17 @@ namespace OSFramework.Maps.Event.Marker {
         public trigger(
             mapId: string,
             markerId: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            ...args: any
+            ...args: unknown[]
         ): void {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.CallbackAsyncInvocation(h, mapId, markerId, ...args)
+                    Helper.CallbackAsyncInvocation(
+                        h.eventHandler,
+                        mapId,
+                        markerId,
+                        ...args
+                    )
                 );
         }
     }

--- a/src/OSFramework/Maps/Event/Marker/MarkerEventsManager.ts
+++ b/src/OSFramework/Maps/Event/Marker/MarkerEventsManager.ts
@@ -68,8 +68,7 @@ namespace OSFramework.Maps.Event.Marker {
         public trigger(
             eventType: MarkerEventType,
             eventInfo?: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            ...args: any
+            ...args: unknown[]
         ): void {
             // Let's first check if the map has any events associated
             // If the event type is ProviderEvent than we need to get the handlers for the eventInfo -> name of the event

--- a/src/OSFramework/Maps/Event/Marker/MarkerProviderEvent.ts
+++ b/src/OSFramework/Maps/Event/Marker/MarkerProviderEvent.ts
@@ -27,7 +27,7 @@ namespace OSFramework.Maps.Event.Marker {
                 .slice(0)
                 .forEach((h) =>
                     Helper.CallbackAsyncInvocation(
-                        h,
+                        h.eventHandler,
                         mapId,
                         markerId,
                         eventName,

--- a/src/OSFramework/Maps/Event/OSMap/AbstractMapEvent.ts
+++ b/src/OSFramework/Maps/Event/OSMap/AbstractMapEvent.ts
@@ -15,13 +15,17 @@ namespace OSFramework.Maps.Event.OSMap {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             mapObj: OSFramework.Maps.OSMap.IMap,
             mapId: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            ...args: any
+            ...args: unknown[]
         ): void {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.CallbackAsyncInvocation(h, mapObj, mapId, ...args)
+                    Helper.CallbackAsyncInvocation(
+                        h.eventHandler,
+                        mapObj,
+                        mapId,
+                        ...args
+                    )
                 );
         }
     }

--- a/src/OSFramework/Maps/Event/OSMap/MapEventsManager.ts
+++ b/src/OSFramework/Maps/Event/OSMap/MapEventsManager.ts
@@ -11,20 +11,19 @@ namespace OSFramework.Maps.Event.OSMap {
      */
     export class MapEventsManager extends AbstractEventsManager<
         MapEventType,
-        OSFramework.Maps.OSMap.IMap
+        Maps.OSMap.IMap
     > {
-        private _map: OSFramework.Maps.OSMap.IMap;
+        private _map: Maps.OSMap.IMap;
 
-        constructor(map: OSFramework.Maps.OSMap.IMap) {
+        constructor(map: Maps.OSMap.IMap) {
             super();
             this._map = map;
         }
 
         protected getInstanceOfEventType(
             eventType: MapEventType
-        ): OSFramework.Maps.Event.IEvent<OSFramework.Maps.OSMap.IMap> {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            let event: OSFramework.Maps.Event.IEvent<OSFramework.Maps.OSMap.IMap>;
+        ): Maps.Event.IEvent<Maps.OSMap.IMap> {
+            let event: Maps.Event.IEvent<Maps.OSMap.IMap>;
 
             switch (eventType) {
                 case MapEventType.Initialized:
@@ -79,14 +78,11 @@ namespace OSFramework.Maps.Event.OSMap {
          * @param eventInfo Extra event information (can be the event name, error code messages, etc.)
          * @param args Other arguments that might be needed (can be coords, useful for the click events, for instance)
          */
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         public trigger(
             eventType: MapEventType,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            map?: OSFramework.Maps.OSMap.IMap,
+            map?: Maps.OSMap.IMap,
             eventInfo?: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            ...args: any
+            ...args: unknown[]
         ): void {
             // Let's first check if the map has any events associated
             // If the event type is ProviderEvent than we need to get the handlers for the eventInfo -> name of the event
@@ -100,12 +96,12 @@ namespace OSFramework.Maps.Event.OSMap {
 
                 switch (eventType) {
                     case MapEventType.Initialized:
-                        handlerEvent.trigger(this._map, this._map.widgetId);
+                        handlerEvent.trigger(map, map.widgetId);
                         break;
                     case MapEventType.OnError:
                         handlerEvent.trigger(
-                            this._map, // Map Object that was clicked
-                            this._map.widgetId, // Id of Map block that was clicked
+                            map, // Map Object that was clicked
+                            map.widgetId, // Id of Map block that was clicked
                             eventInfo, // Error Code
                             ...args // Extra Error messages that might come from the Provider APIs (geocoding for instance)
                         );
@@ -113,8 +109,8 @@ namespace OSFramework.Maps.Event.OSMap {
                     // The following event is being deprecated. It should get removed soon.
                     case MapEventType.OnEventTriggered:
                         handlerEvent.trigger(
-                            this._map, // Map Object that triggered the event
-                            this._map.widgetId, // Id of Map block that triggered the event
+                            map, // Map Object that triggered the event
+                            map.widgetId, // Id of Map block that triggered the event
                             eventInfo // Name of the event that got raised
                         );
                         break;
@@ -127,8 +123,8 @@ namespace OSFramework.Maps.Event.OSMap {
                                 eventInfo as MapEventType
                             );
                             handler.trigger(
-                                this._map, // Map Object that triggered the event
-                                this._map.widgetId, // Id of Map block that triggered the event
+                                map, // Map Object that triggered the event
+                                map.widgetId, // Id of Map block that triggered the event
                                 eventInfo, // Name of the event that got raised
                                 ...args // Coordinates retrieved from the Map event that got triggered
                             );
@@ -139,7 +135,7 @@ namespace OSFramework.Maps.Event.OSMap {
                     default:
                         this._map.mapEvents.trigger(
                             MapEventType.OnError,
-                            this._map,
+                            map,
                             Enum.ErrorCodes.GEN_UnsupportedEventMap,
                             `${eventType}`
                         );

--- a/src/OSFramework/Maps/Event/OSMap/MapOnError.ts
+++ b/src/OSFramework/Maps/Event/OSMap/MapOnError.ts
@@ -27,7 +27,7 @@ namespace OSFramework.Maps.Event.OSMap {
                 .slice(0)
                 .forEach((h) =>
                     Helper.CallbackAsyncInvocation(
-                        h,
+                        h.eventHandler,
                         mapObj,
                         mapId,
                         eventName,

--- a/src/OSFramework/Maps/Event/OSMap/MapProviderEvent.ts
+++ b/src/OSFramework/Maps/Event/OSMap/MapProviderEvent.ts
@@ -32,7 +32,7 @@ namespace OSFramework.Maps.Event.OSMap {
                     )
                 ) {
                     Helper.CallbackAsyncInvocation(
-                        h,
+                        h.eventHandler,
                         mapObj,
                         mapId,
                         eventName,

--- a/src/OSFramework/Maps/Event/SearchPlaces/AbstractSearchPlacesEvent.ts
+++ b/src/OSFramework/Maps/Event/SearchPlaces/AbstractSearchPlacesEvent.ts
@@ -15,14 +15,13 @@ namespace OSFramework.Maps.Event.SearchPlaces {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             searchPlacesObj: OSFramework.Maps.SearchPlaces.ISearchPlaces,
             searchPlacesId: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            ...args: any
+            ...args: unknown[]
         ): void {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
                     Helper.CallbackAsyncInvocation(
-                        h,
+                        h.eventHandler,
                         searchPlacesObj,
                         searchPlacesId,
                         ...args

--- a/src/OSFramework/Maps/Event/SearchPlaces/SearchPlacesEventsManager.ts
+++ b/src/OSFramework/Maps/Event/SearchPlaces/SearchPlacesEventsManager.ts
@@ -75,8 +75,7 @@ namespace OSFramework.Maps.Event.SearchPlaces {
          */
         public trigger(
             eventType: SearchPlacesEventType,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            searchPlaces?: OSFramework.Maps.SearchPlaces.ISearchPlaces,
+            searchPlaces?: Maps.SearchPlaces.ISearchPlaces,
             eventInfo?: string,
             searchPlacesEventParams?: Maps.SearchPlaces.ISearchPlacesEventParams,
             ...args: unknown[]
@@ -88,18 +87,16 @@ namespace OSFramework.Maps.Event.SearchPlaces {
                 switch (eventType) {
                     case SearchPlacesEventType.Initialized:
                         handlerEvent.trigger(
-                            this._searchPlaces, // SearchPlaces Object that was initialized
-                            this._searchPlaces.widgetId ||
-                                this._searchPlaces.uniqueId // Id of SearchPlaces block that was initialized
+                            searchPlaces, // SearchPlaces Object that was initialized
+                            searchPlaces.widgetId || searchPlaces.uniqueId // Id of SearchPlaces block that was initialized
                         );
                         break;
                     case SearchPlacesEventType.OnError:
                         handlerEvent.trigger(
-                            this._searchPlaces, // SearchPlaces Object that had the error
-                            this._searchPlaces.widgetId ||
-                                this._searchPlaces.uniqueId, // Id of SearchPlaces block that had the error
+                            searchPlaces, // SearchPlaces Object that had the error
+                            searchPlaces.widgetId || searchPlaces.uniqueId, // Id of SearchPlaces block that had the error
                             eventInfo, // Error Code
-                            args[0] // Extra Error messages that might come from the Provider APIs (geocoding for instance)
+                            ...args // Extra Error messages that might come from the Provider APIs (geocoding for instance)
                         );
                         break;
                     case SearchPlacesEventType.OnPlaceSelect:

--- a/src/OSFramework/Maps/Event/SearchPlaces/SearchPlacesOnError.ts
+++ b/src/OSFramework/Maps/Event/SearchPlaces/SearchPlacesOnError.ts
@@ -27,7 +27,7 @@ namespace OSFramework.Maps.Event.SearchPlaces {
                 .slice(0)
                 .forEach((h) =>
                     Helper.CallbackAsyncInvocation(
-                        h,
+                        h.eventHandler,
                         searchPlacesObj,
                         searchPlacesId,
                         eventName,

--- a/src/OSFramework/Maps/Event/Shape/AbstractShapeEvent.ts
+++ b/src/OSFramework/Maps/Event/Shape/AbstractShapeEvent.ts
@@ -8,19 +8,21 @@ namespace OSFramework.Maps.Event.Shape {
      * @class AbstractShapeEvent
      * @extends {AbstractEvent<string>}
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     export abstract class AbstractShapeEvent extends AbstractEvent<string> {
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
         public trigger(
             mapId: string,
             shapeId: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            ...args: any
+            ...args: unknown[]
         ): void {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
-                    Helper.CallbackAsyncInvocation(h, mapId, shapeId, ...args)
+                    Helper.CallbackAsyncInvocation(
+                        h.eventHandler,
+                        mapId,
+                        shapeId,
+                        ...args
+                    )
                 );
         }
     }

--- a/src/OSFramework/Maps/Event/Shape/ShapeEventsManager.ts
+++ b/src/OSFramework/Maps/Event/Shape/ShapeEventsManager.ts
@@ -55,10 +55,8 @@ namespace OSFramework.Maps.Event.Shape {
          */
         public trigger(
             eventType: ShapeEventType,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             eventInfo?: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-            ...args: any
+            ...args: unknown[]
         ): void {
             // Let's first check if the shape has any events associated
             // If the event type is ProviderEvent than we need to get the handlers for the eventInfo -> name of the event

--- a/src/OSFramework/Maps/Event/Shape/ShapeProviderEvent.ts
+++ b/src/OSFramework/Maps/Event/Shape/ShapeProviderEvent.ts
@@ -17,17 +17,16 @@ namespace OSFramework.Maps.Event.Shape {
          * @param coords Event properties as coordinates and location
          */
         public trigger(
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             mapId: string,
             shapeId: string,
             eventName: string,
-            coords: OSFramework.Maps.OSStructures.OSMap.OSShapeCoordinates
+            coords: OSStructures.OSMap.OSShapeCoordinates
         ): void {
             this.handlers
                 .slice(0)
                 .forEach((h) =>
                     Helper.CallbackAsyncInvocation(
-                        h,
+                        h.eventHandler,
                         mapId,
                         shapeId,
                         eventName,

--- a/src/OSFramework/Maps/Feature/IMarkerClusterer.ts
+++ b/src/OSFramework/Maps/Feature/IMarkerClusterer.ts
@@ -14,8 +14,7 @@ namespace OSFramework.Maps.Feature {
          * Sets the marker clusterer configs
          * @param configs Configurations from the structure MarkerClusterer
          */
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        changeProperty(propertyName: string, value: any): void;
+        changeProperty(propertyName: string, value: unknown): void;
         /**
          * Removes a marker from the cluster
          * @param marker Marker Object from OSFramework that is going to be removed from the cluster

--- a/src/OSFramework/Maps/FileLayer/AbstractFileLayer.ts
+++ b/src/OSFramework/Maps/FileLayer/AbstractFileLayer.ts
@@ -13,8 +13,7 @@ namespace OSFramework.Maps.FileLayer {
         private _widgetId: string;
 
         protected _built: boolean;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        protected _createElements: Array<any>;
+        protected _createElements: Array<unknown>;
         protected _fileLayerEvents: Event.FileLayer.FileLayersEventsManager;
         protected _provider: W;
 
@@ -32,8 +31,8 @@ namespace OSFramework.Maps.FileLayer {
         public get config(): T {
             return this._config;
         }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public get createdElements(): Array<any> {
+
+        public get createdElements(): Array<unknown> {
             return this._createElements;
         }
         public get fileLayerEvents(): Event.FileLayer.FileLayersEventsManager {
@@ -82,8 +81,10 @@ namespace OSFramework.Maps.FileLayer {
             this._setWidgetId();
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        public changeProperty(propertyName: string, propertyValue: any): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             //Update Shape's config when the property is available
             if (this.config.hasOwnProperty(propertyName)) {
                 this.config[propertyName] = propertyValue;
@@ -106,9 +107,8 @@ namespace OSFramework.Maps.FileLayer {
             return id === this._uniqueId || id === this.widgetId;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): Configuration.IConfigurationFileLayer {
-            return this._config.getProviderConfig();
+            return this._config.getProviderConfig() as Configuration.IConfigurationFileLayer;
         }
 
         public abstract refreshProviderEvents(): void;

--- a/src/OSFramework/Maps/FileLayer/IFileLayer.ts
+++ b/src/OSFramework/Maps/FileLayer/IFileLayer.ts
@@ -5,8 +5,7 @@ namespace OSFramework.Maps.FileLayer {
             Interface.ISearchById,
             Interface.IDisposable {
         config: Configuration.IConfigurationFileLayer; //IConfigurationFileLayer
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        createdElements: Array<any>;
+        createdElements: Array<unknown>;
         /** Events from the FileLayer */
         fileLayerEvents: Event.FileLayer.FileLayersEventsManager;
         isReady: boolean;
@@ -16,8 +15,7 @@ namespace OSFramework.Maps.FileLayer {
         uniqueId: string;
         widgetId: string;
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        changeProperty(propertyName: string, propertyValue: any): void;
+        changeProperty(propertyName: string, propertyValue: unknown): void;
         /**
          * Refreshes the Events of the FileLayer Provider after Subscribing/Unsubscribing events
          */

--- a/src/OSFramework/Maps/HeatmapLayer/AbstractHeatmapLayer.ts
+++ b/src/OSFramework/Maps/HeatmapLayer/AbstractHeatmapLayer.ts
@@ -13,7 +13,6 @@ namespace OSFramework.Maps.HeatmapLayer {
         private _widgetId: string;
 
         protected _built: boolean;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         protected _provider: W;
 
         constructor(map: OSMap.IMap, uniqueId: string, config: T) {
@@ -65,8 +64,10 @@ namespace OSFramework.Maps.HeatmapLayer {
             this._setWidgetId();
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        public changeProperty(propertyName: string, propertyValue: any): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             //Update Shape's config when the property is available
             if (this.config.hasOwnProperty(propertyName)) {
                 this.config[propertyName] = propertyValue;
@@ -89,9 +90,8 @@ namespace OSFramework.Maps.HeatmapLayer {
             return id === this._uniqueId || id === this.widgetId;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): Configuration.IConfigurationHeatmapLayer {
-            return this._config.getProviderConfig();
+            return this._config.getProviderConfig() as Configuration.IConfigurationHeatmapLayer;
         }
     }
 }

--- a/src/OSFramework/Maps/HeatmapLayer/IHeatmapLayer.ts
+++ b/src/OSFramework/Maps/HeatmapLayer/IHeatmapLayer.ts
@@ -12,7 +12,6 @@ namespace OSFramework.Maps.HeatmapLayer {
         uniqueId: string;
         widgetId: string;
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        changeProperty(propertyName: string, propertyValue: any): void;
+        changeProperty(propertyName: string, propertyValue: unknown): void;
     }
 }

--- a/src/OSFramework/Maps/Helper/AsyncInvocation.ts
+++ b/src/OSFramework/Maps/Helper/AsyncInvocation.ts
@@ -1,8 +1,11 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.Maps.Helper {
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-    export function CallbackAsyncInvocation(callback: any, ...args: any) {
-        if (callback.eventHandler)
-            setTimeout(() => callback.eventHandler(...args), 0);
+    export function CallbackAsyncInvocation(
+        callback: Callbacks.Generic,
+        ...args: unknown[]
+    ): void {
+        if (callback) {
+            setTimeout(callback, 0, ...args);
+        }
     }
 }

--- a/src/OSFramework/Maps/Marker/AbstractMarker.ts
+++ b/src/OSFramework/Maps/Marker/AbstractMarker.ts
@@ -2,12 +2,11 @@
 namespace OSFramework.Maps.Marker {
     export abstract class AbstractMarker<
         W,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         Z extends Configuration.IConfigurationMarker
     > implements IMarkerGeneric<W>
     {
         /** Configuration reference */
-        private _config: Configuration.IConfigurationMarker;
+        private _config: Z;
         private _map: OSMap.IMap;
         private _uniqueId: string;
         private _widgetId: string;
@@ -22,7 +21,7 @@ namespace OSFramework.Maps.Marker {
             map: OSMap.IMap,
             uniqueId: string,
             type: Enum.MarkerType,
-            config: Configuration.IConfigurationMarker
+            config: Z
         ) {
             this._map = map;
             this._uniqueId = uniqueId;
@@ -32,7 +31,7 @@ namespace OSFramework.Maps.Marker {
         }
         public abstract get markerTag(): string;
 
-        public get config(): Configuration.IConfigurationMarker {
+        public get config(): Z {
             return this._config;
         }
         public get hasPopup(): boolean {
@@ -83,8 +82,10 @@ namespace OSFramework.Maps.Marker {
                 : undefined;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        public changeProperty(propertyName: string, propertyValue: any): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             //Update Marker's config when the property is available
             if (this.config.hasOwnProperty(propertyName)) {
                 this.config[propertyName] = propertyValue;
@@ -106,9 +107,8 @@ namespace OSFramework.Maps.Marker {
             return id === this._uniqueId || id === this._widgetId;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public getProviderConfig(): any {
-            return this._config.getProviderConfig();
+        public getProviderConfig(): unknown {
+            return this.config.getProviderConfig();
         }
 
         public abstract refreshProviderEvents(): void;

--- a/src/OSFramework/Maps/Marker/Factory.ts
+++ b/src/OSFramework/Maps/Marker/Factory.ts
@@ -5,7 +5,7 @@ namespace OSFramework.Maps.Marker {
             map: OSMap.IMap,
             markerId: string,
             type: Enum.MarkerType,
-            configs: Configuration.IConfiguration
+            configs: JSON
         ): Marker.IMarker {
             switch (map.providerType) {
                 case Enum.ProviderType.Google:
@@ -13,7 +13,7 @@ namespace OSFramework.Maps.Marker {
                         map,
                         markerId,
                         type,
-                        configs as Provider.Maps.Google.Configuration.Marker.GoogleMarkerConfig
+                        configs
                     );
 
                 case Enum.ProviderType.Leaflet:
@@ -21,7 +21,7 @@ namespace OSFramework.Maps.Marker {
                         map,
                         markerId,
                         type,
-                        configs as Provider.Maps.Leaflet.Configuration.Marker.LeafletMarkerConfig
+                        configs
                     );
                 default:
                     throw new Error(

--- a/src/OSFramework/Maps/Marker/IMarker.ts
+++ b/src/OSFramework/Maps/Marker/IMarker.ts
@@ -17,8 +17,7 @@ namespace OSFramework.Maps.Marker {
         widgetId: string;
 
         build(): void;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        changeProperty(propertyName: string, propertyValue: any): void;
+        changeProperty(propertyName: string, propertyValue: unknown): void;
         dispose(): void;
         /**
          * Refreshes the Events of the Marker Provider after Subscribing/Unsubscribing events

--- a/src/OSFramework/Maps/OSCallback/CallbackSignatures.ts
+++ b/src/OSFramework/Maps/OSCallback/CallbackSignatures.ts
@@ -6,8 +6,7 @@ namespace OSFramework.Maps.Callbacks {
     /**
      * This is the most generic callback signature and can be used even for internal events
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    export type Generic = { (...ags): any };
+    export type Generic = { (...ags): unknown };
 
     /**
      * This is the most generic callback signature for events existing in OutSystems code.

--- a/src/OSFramework/Maps/OSCallback/CallbackSignatures.ts
+++ b/src/OSFramework/Maps/OSCallback/CallbackSignatures.ts
@@ -6,11 +6,11 @@ namespace OSFramework.Maps.Callbacks {
     /**
      * This is the most generic callback signature and can be used even for internal events
      */
-    export type Generic = { (...ags): unknown };
+    export type Generic = (...ags: unknown[]) => unknown;
 
     /**
      * This is the most generic callback signature for events existing in OutSystems code.
      * @param {string} mapID enables the OutSystems code to understand which map triggered the event
      */
-    export type OSGeneric = { (mapID: string, ...args): void };
+    export type OSGeneric = (mapID: string, ...args: unknown[]) => void;
 }

--- a/src/OSFramework/Maps/OSCallback/DrawingToolts.ts
+++ b/src/OSFramework/Maps/OSCallback/DrawingToolts.ts
@@ -15,8 +15,7 @@ namespace OSFramework.Maps.Callbacks.DrawingTools {
             mapId: string,
             drawingToolsId: string,
             drawingToolsObj: OSFramework.Maps.DrawingTools.IDrawingTools,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            ...args: any
+            ...args: unknown[]
         ): void;
     };
 }

--- a/src/OSFramework/Maps/OSCallback/FileLayer.ts
+++ b/src/OSFramework/Maps/OSCallback/FileLayer.ts
@@ -14,8 +14,7 @@ namespace OSFramework.Maps.Callbacks.FileLayer {
             mapId: string,
             fileLayerId: string,
             fileLayerObj: OSFramework.Maps.FileLayer.IFileLayer,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            ...args: any
+            ...args: unknown[]
         ): void;
     };
 }

--- a/src/OSFramework/Maps/OSCallback/Marker.ts
+++ b/src/OSFramework/Maps/OSCallback/Marker.ts
@@ -14,8 +14,7 @@ namespace OSFramework.Maps.Callbacks.Marker {
             mapId: string,
             markerId: string,
             markerObj: OSFramework.Maps.Marker.IMarker,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            ...args: any
+            ...args: unknown[]
         ): void;
     };
 }

--- a/src/OSFramework/Maps/OSCallback/Shape.ts
+++ b/src/OSFramework/Maps/OSCallback/Shape.ts
@@ -14,8 +14,7 @@ namespace OSFramework.Maps.Callbacks.Shape {
             mapId: string,
             shapeId: string,
             shapeObj: OSFramework.Maps.Shape.IShape,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            ...args: any
+            ...args: unknown[]
         ): void;
     };
 }

--- a/src/OSFramework/Maps/OSMap/AbstractMap.ts
+++ b/src/OSFramework/Maps/OSMap/AbstractMap.ts
@@ -161,8 +161,10 @@ namespace OSFramework.Maps.OSMap {
             ).id;
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public changeProperty(propertyName: string, propertyValue: any): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             //Update Map's config when the property is available
             if (this.config.hasOwnProperty(propertyName)) {
                 this.config[propertyName] = propertyValue;
@@ -433,36 +435,31 @@ namespace OSFramework.Maps.OSMap {
         public abstract changeDrawingToolsProperty(
             drawingToolsId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void;
 
         public abstract changeFileLayerProperty(
             fileLayerId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void;
 
         public abstract changeHeatmapLayerProperty(
             heatmapLayerId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void;
 
         public abstract changeMarkerProperty(
             markerId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void;
 
         public abstract changeShapeProperty(
             shapeId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void;
 
         public abstract refresh(): void;

--- a/src/OSFramework/Maps/OSMap/Factory.ts
+++ b/src/OSFramework/Maps/OSMap/Factory.ts
@@ -5,7 +5,7 @@ namespace OSFramework.Maps.OSMap {
             provider: Enum.ProviderType,
             type: Enum.MapType,
             mapdId: string,
-            configs: Configuration.IConfiguration
+            configs: JSON
         ): OSMap.IMap {
             switch (provider) {
                 case Enum.ProviderType.Google:

--- a/src/OSFramework/Maps/OSMap/IMap.ts
+++ b/src/OSFramework/Maps/OSMap/IMap.ts
@@ -21,8 +21,7 @@ namespace OSFramework.Maps.OSMap {
         /** Get all Markers from the Map */
         markers: Array<OSFramework.Maps.Marker.IMarker>;
         /** Get all Markers that have finished building its provider */
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        markersReady: Array<any>;
+        markersReady: Array<unknown>;
         /** Map provider */
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         provider: any;
@@ -82,8 +81,7 @@ namespace OSFramework.Maps.OSMap {
         changeDrawingToolsProperty(
             drawingToolsId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void;
         /**
          * Change property of a fileLayer from the FileLayer by specifying the property name and the new value
@@ -94,8 +92,7 @@ namespace OSFramework.Maps.OSMap {
         changeFileLayerProperty(
             fileLayerId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void;
         /**
          * Change property of a heatmapLayer from the HeatmapLayer by specifying the property name and the new value
@@ -106,8 +103,7 @@ namespace OSFramework.Maps.OSMap {
         changeHeatmapLayerProperty(
             heatmapLayerId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void;
         /**
          * Change property of a marker from the Map by specifying the property name and the new value
@@ -118,16 +114,14 @@ namespace OSFramework.Maps.OSMap {
         changeMarkerProperty(
             markerId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void;
         /**
          * Change property of the Map by specifying the property name and the new value
          * @param propertyName name of the property
          * @param propertyValue new value of the property
          */
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        changeProperty(propertyName: string, propertyValue: any): void;
+        changeProperty(propertyName: string, propertyValue: unknown): void;
         /**
          * Change property of a shape from the Map by specifying the property name and the new value
          * @param shapeId id of the Shape
@@ -137,8 +131,7 @@ namespace OSFramework.Maps.OSMap {
         changeShapeProperty(
             shapeId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void;
         /**
          * Get the FileLayer from the Map by giving a fileLayerId

--- a/src/OSFramework/Maps/OSStructures/API.CircleProperties.ts
+++ b/src/OSFramework/Maps/OSStructures/API.CircleProperties.ts
@@ -1,9 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.Maps.OSStructures.API {
     export class CircleProperties {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public Center: OSStructures.OSMap.OSCoordinates;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public Radius: number;
     }
 }

--- a/src/OSFramework/Maps/OSStructures/OSMap.Directions.ts
+++ b/src/OSFramework/Maps/OSStructures/OSMap.Directions.ts
@@ -2,10 +2,9 @@
 namespace OSFramework.Maps.OSStructures.Directions {
     /** Return Message that is sent to Service Studio */
     export class DirectionLegs {
-        public origin: OSFramework.Maps.OSStructures.OSMap.Coordinates;
-        // eslint-disable-next-line @typescript-eslint/member-ordering, @typescript-eslint/no-unused-vars
-        public destination: OSFramework.Maps.OSStructures.OSMap.Coordinates;
+        public destination: OSMap.Coordinates;
         public distance: number;
         public duration: number;
+        public origin: OSMap.Coordinates;
     }
 }

--- a/src/OSFramework/Maps/SearchPlaces/AbstractSearchPlaces.ts
+++ b/src/OSFramework/Maps/SearchPlaces/AbstractSearchPlaces.ts
@@ -2,7 +2,6 @@
 namespace OSFramework.Maps.SearchPlaces {
     export abstract class AbstractSearchPlaces<
         W,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         T extends Configuration.IConfigurationSearchPlaces
     > implements ISearchPlaces
     {
@@ -72,8 +71,10 @@ namespace OSFramework.Maps.SearchPlaces {
             this._setWidgetId();
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        public changeProperty(propertyName: string, propertyValue: any): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             //Update SearchPlaces' config when the property is available
             if (this.config.hasOwnProperty(propertyName)) {
                 this.config[propertyName] = propertyValue;
@@ -97,9 +98,8 @@ namespace OSFramework.Maps.SearchPlaces {
             return id === this._uniqueId || id === this.widgetId;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public getProviderConfig(): any {
-            return this._config.getProviderConfig();
+        public getProviderConfig(): unknown {
+            return this.config.getProviderConfig();
         }
     }
 }

--- a/src/OSFramework/Maps/SearchPlaces/ISearchPlaces.ts
+++ b/src/OSFramework/Maps/SearchPlaces/ISearchPlaces.ts
@@ -14,7 +14,6 @@ namespace OSFramework.Maps.SearchPlaces {
         uniqueId: string;
         widgetId: string;
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        changeProperty(propertyName: string, propertyValue: any): void;
+        changeProperty(propertyName: string, propertyValue: unknown): void;
     }
 }

--- a/src/OSFramework/Maps/Shape/AbstractShape.ts
+++ b/src/OSFramework/Maps/Shape/AbstractShape.ts
@@ -80,6 +80,18 @@ namespace OSFramework.Maps.Shape {
             this.shapeEvents.trigger(Event.Shape.ShapeEventType.Initialized);
         }
 
+        protected triggerShapeChangedEvent(): void {
+            const shapeLocation = this.getShapeCoordinates();
+
+            this.shapeEvents.trigger(
+                // EventType
+                Maps.Event.Shape.ShapeEventType.ProviderEvent,
+                // EventName
+                Maps.Helper.Constants.shapeChangedEvent,
+                shapeLocation
+            );
+        }
+
         public build(): void {
             if (this._built) return;
 
@@ -87,8 +99,10 @@ namespace OSFramework.Maps.Shape {
             this._setWidgetId();
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        public changeProperty(propertyName: string, propertyValue: any): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             //Update Shape's config when the property is available
             if (this.config.hasOwnProperty(propertyName)) {
                 this.config[propertyName] = propertyValue;
@@ -111,30 +125,17 @@ namespace OSFramework.Maps.Shape {
             return id === this._uniqueId || id === this.widgetId;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public getProviderConfig(): any {
-            return this._config.getProviderConfig();
+        public getProviderConfig(): unknown {
+            return this.config.getProviderConfig();
         }
 
         public validateProviderEvent(eventName: string): boolean {
             return this.shapeProviderEvents.indexOf(eventName) !== -1;
         }
 
-        protected triggerShapeChangedEvent() {
-            const shapeLocation = this.getShapeCoordinates();
-
-            this.shapeEvents.trigger(
-                // EventType
-                OSFramework.Maps.Event.Shape.ShapeEventType.ProviderEvent,
-                // EventName
-                OSFramework.Maps.Helper.Constants.shapeChangedEvent,
-                shapeLocation
-            );
-        }
-
         protected abstract get invalidShapeLocationErrorCode(): Enum.ErrorCodes;
 
-        protected abstract getShapeCoordinates(): OSFramework.Maps.OSStructures.OSMap.OSShapeCoordinates;
+        protected abstract getShapeCoordinates(): Maps.OSStructures.OSMap.OSShapeCoordinates;
         public abstract refreshProviderEvents(): void;
         public abstract get shapeProviderEvents(): Array<string>;
         public abstract get shapeTag(): string;

--- a/src/OSFramework/Maps/Shape/Factory.ts
+++ b/src/OSFramework/Maps/Shape/Factory.ts
@@ -5,7 +5,7 @@ namespace OSFramework.Maps.Shape {
             map: OSMap.IMap,
             shapeId: string,
             type: Enum.ShapeType,
-            configs: JSON
+            configs: Configuration.IConfigurationShape
         ): Shape.IShape {
             switch (map.providerType) {
                 case Enum.ProviderType.Google:
@@ -14,14 +14,14 @@ namespace OSFramework.Maps.Shape {
                         map,
                         shapeId,
                         type,
-                        configs as JSON
+                        configs
                     );
                 case Enum.ProviderType.Leaflet:
                     return Provider.Maps.Leaflet.Shape.ShapeFactory.MakeShape(
                         map,
                         shapeId,
                         type,
-                        configs as JSON
+                        configs
                     );
                 default:
                     throw new Error(

--- a/src/OSFramework/Maps/Shape/IShape.ts
+++ b/src/OSFramework/Maps/Shape/IShape.ts
@@ -19,8 +19,7 @@ namespace OSFramework.Maps.Shape {
         widgetId: string;
 
         build(): void;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        changeProperty(propertyName: string, propertyValue: any): void;
+        changeProperty(propertyName: string, propertyValue: unknown): void;
         dispose(): void;
         /**
          * Refreshes the Events of the Shape Provider after Subscribing/Unsubscribing events

--- a/src/OutSystems/Maps/MapAPI/DrawingToolsManager.Events.ts
+++ b/src/OutSystems/Maps/MapAPI/DrawingToolsManager.Events.ts
@@ -1,19 +1,16 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OutSystems.Maps.MapAPI.DrawingToolsManager.Events {
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
     const _pendingEvents: Map<
         string,
         {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            cb: any;
+            cb: OSFramework.Maps.Callbacks.Generic;
             event: OSFramework.Maps.Event.DrawingTools.DrawingToolsEventType;
             uniqueId: string; //Event unique identifier
         }[]
     > = new Map<
         string,
         {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            cb: any;
+            cb: OSFramework.Maps.Callbacks.Generic;
             event: OSFramework.Maps.Event.DrawingTools.DrawingToolsEventType;
             uniqueId: string; //Event unique identifier
         }[]

--- a/src/OutSystems/Maps/MapAPI/DrawingToolsManager.ts
+++ b/src/OutSystems/Maps/MapAPI/DrawingToolsManager.ts
@@ -117,8 +117,7 @@ namespace OutSystems.Maps.MapAPI.DrawingToolsManager {
     export function ChangeProperty(
         drawingToolsId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         const drawingTools = GetDrawingToolsById(drawingToolsId);
         const map = drawingTools.map;
@@ -143,8 +142,7 @@ namespace OutSystems.Maps.MapAPI.DrawingToolsManager {
     export function ChangeToolProperty(
         toolId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         const drawingToolsId = GetDrawingToolsByToolUniqueId(toolId);
         const drawingTools = GetDrawingToolsById(drawingToolsId, false);
@@ -314,8 +312,7 @@ namespace MapAPI.DrawingToolsManager {
     export function ChangeProperty(
         drawingToolsId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         OSFramework.Maps.Helper.LogWarningMessage(
             `${OSFramework.Maps.Helper.warningMessage} 'OutSystems.Maps.MapAPI.DrawingToolsManager.ChangeProperty()'`
@@ -330,8 +327,7 @@ namespace MapAPI.DrawingToolsManager {
     export function ChangeToolProperty(
         toolId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         OSFramework.Maps.Helper.LogWarningMessage(
             `${OSFramework.Maps.Helper.warningMessage} 'OutSystems.Maps.MapAPI.DrawingToolsManager.ChangeToolProperty()'`

--- a/src/OutSystems/Maps/MapAPI/FileLayerManager.Events.ts
+++ b/src/OutSystems/Maps/MapAPI/FileLayerManager.Events.ts
@@ -1,19 +1,16 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OutSystems.Maps.MapAPI.FileLayerManager.Events {
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
     const _pendingEvents: Map<
         string,
         {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            cb: any;
+            cb: OSFramework.Maps.Callbacks.Generic;
             event: OSFramework.Maps.Event.FileLayer.FileLayersEventType;
             uniqueId: string; //Event unique identifier
         }[]
     > = new Map<
         string,
         {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            cb: any;
+            cb: OSFramework.Maps.Callbacks.Generic;
             event: OSFramework.Maps.Event.FileLayer.FileLayersEventType;
             uniqueId: string; //Event unique identifier
         }[]

--- a/src/OutSystems/Maps/MapAPI/FileLayerManager.ts
+++ b/src/OutSystems/Maps/MapAPI/FileLayerManager.ts
@@ -48,8 +48,7 @@ namespace OutSystems.Maps.MapAPI.FileLayerManager {
     export function ChangeProperty(
         fileLayerId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         const fileLayer = GetFileLayerById(fileLayerId);
         const map = fileLayer.map;
@@ -70,7 +69,6 @@ namespace OutSystems.Maps.MapAPI.FileLayerManager {
      * @param {string} configs configurations for the FileLayer in JSON format
      * @returns {*}  {FileLayer.IFileLayer} instance of the FileLayer
      */
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     export function CreateFileLayer(
         fileLayerId: string,
         configs: string
@@ -150,8 +148,7 @@ namespace MapAPI.FileLayerManager {
     export function ChangeProperty(
         fileLayerId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         OSFramework.Maps.Helper.LogWarningMessage(
             `${OSFramework.Maps.Helper.warningMessage} 'OutSystems.Maps.MapAPI.FileLayerManager.ChangeProperty()'`

--- a/src/OutSystems/Maps/MapAPI/HeatmapLayerManager.ts
+++ b/src/OutSystems/Maps/MapAPI/HeatmapLayerManager.ts
@@ -52,8 +52,7 @@ namespace OutSystems.Maps.MapAPI.HeatmapLayerManager {
     export function ChangeProperty(
         heatmapLayerId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         const heatmapLayer = GetHeatmapLayerById(heatmapLayerId);
         const map = heatmapLayer.map;
@@ -154,8 +153,7 @@ namespace MapAPI.HeatmapLayerManager {
     export function ChangeProperty(
         heatmapLayerId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         OSFramework.Maps.Helper.LogWarningMessage(
             `${OSFramework.Maps.Helper.warningMessage} 'OutSystems.Maps.MapAPI.HeatmapLayerManager.ChangeProperty()'`

--- a/src/OutSystems/Maps/MapAPI/MapManager.Events.ts
+++ b/src/OutSystems/Maps/MapAPI/MapManager.Events.ts
@@ -1,19 +1,16 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OutSystems.Maps.MapAPI.MapManager.Events {
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
     const _pendingEvents: Map<
         string,
         {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            cb: any;
+            cb: OSFramework.Maps.Callbacks.Generic;
             event: OSFramework.Maps.Event.OSMap.MapEventType;
             uniqueId: string; //Event unique identifier
         }[]
     > = new Map<
         string,
         {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            cb: any;
+            cb: OSFramework.Maps.Callbacks.Generic;
             event: OSFramework.Maps.Event.OSMap.MapEventType;
             uniqueId: string; //Event unique identifier
         }[]
@@ -76,7 +73,6 @@ namespace OutSystems.Maps.MapAPI.MapManager.Events {
     export function Subscribe(
         mapId: string,
         eventName: OSFramework.Maps.Event.OSMap.MapEventType,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         callback: OSFramework.Maps.Callbacks.OSMap.Event
     ): void {
         // Let's make sure that if the Map doesn't exist, we don't throw and exception but instead add the handler to the pendingEvents

--- a/src/OutSystems/Maps/MapAPI/MapManager.ts
+++ b/src/OutSystems/Maps/MapAPI/MapManager.ts
@@ -14,8 +14,7 @@ namespace OutSystems.Maps.MapAPI.MapManager {
     export function ChangeProperty(
         mapId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         const map = GetMapById(mapId);
 
@@ -251,8 +250,7 @@ namespace MapAPI.MapManager {
     export function ChangeProperty(
         mapId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         OSFramework.Maps.Helper.LogWarningMessage(
             `${OSFramework.Maps.Helper.warningMessage} 'OutSystems.Maps.MapAPI.MapManager.ChangeProperty()'`

--- a/src/OutSystems/Maps/MapAPI/MarkerManager.Events.ts
+++ b/src/OutSystems/Maps/MapAPI/MarkerManager.Events.ts
@@ -1,19 +1,16 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OutSystems.Maps.MapAPI.MarkerManager.Events {
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
     const _pendingEvents: Map<
         string,
         {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            cb: any;
+            cb: OSFramework.Maps.Callbacks.Generic;
             event: OSFramework.Maps.Event.Marker.MarkerEventType;
             uniqueId: string; //Event unique identifier
         }[]
     > = new Map<
         string,
         {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            cb: any;
+            cb: OSFramework.Maps.Callbacks.Generic;
             event: OSFramework.Maps.Event.Marker.MarkerEventType;
             uniqueId: string; //Event unique identifier
         }[]
@@ -97,7 +94,6 @@ namespace OutSystems.Maps.MapAPI.MarkerManager.Events {
     export function SubscribeByUniqueId(
         eventUniqueId: string,
         eventName: OSFramework.Maps.Event.Marker.MarkerEventType,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         callback: OSFramework.Maps.Callbacks.Marker.Event
     ): void {
         // Let's make sure that if the Map doesn't exist, we don't throw and exception but instead add the handler to the pendingEvents
@@ -226,7 +222,6 @@ namespace MapAPI.MarkerManager.Events {
     export function SubscribeByUniqueId(
         eventUniqueId: string,
         eventName: OSFramework.Maps.Event.Marker.MarkerEventType,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         callback: OSFramework.Maps.Callbacks.Marker.Event
     ): void {
         OSFramework.Maps.Helper.LogWarningMessage(

--- a/src/OutSystems/Maps/MapAPI/MarkerManager.ts
+++ b/src/OutSystems/Maps/MapAPI/MarkerManager.ts
@@ -14,8 +14,7 @@ namespace OutSystems.Maps.MapAPI.MarkerManager {
     export function ChangeProperty(
         markerId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         const marker = GetMarkerById(markerId);
         const map = marker.map;
@@ -231,10 +230,10 @@ namespace OutSystems.Maps.MapAPI.MarkerManager {
             allMaps.find((map: OSFramework.Maps.OSMap.IMap) => {
                 return (marker =
                     map.drawingTools &&
-                    map.drawingTools.createdElements.find(
+                    (map.drawingTools.createdElements.find(
                         (marker: OSFramework.Maps.Marker.IMarker) =>
                             marker.equalsToID(markerId)
-                    ));
+                    ) as OSFramework.Maps.Marker.IMarker));
             });
 
             // If still wasn't found, then it does not exist and throw error
@@ -284,8 +283,7 @@ namespace MapAPI.MarkerManager {
     export function ChangeProperty(
         markerId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         OSFramework.Maps.Helper.LogWarningMessage(
             `${OSFramework.Maps.Helper.warningMessage} 'OutSystems.Maps.MapAPI.MarkerManager.ChangeProperty()'`

--- a/src/OutSystems/Maps/MapAPI/ShapeManager.Events.ts
+++ b/src/OutSystems/Maps/MapAPI/ShapeManager.Events.ts
@@ -1,19 +1,16 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OutSystems.Maps.MapAPI.ShapeManager.Events {
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
     const _pendingEvents: Map<
         string,
         {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            cb: any;
+            cb: OSFramework.Maps.Callbacks.Generic;
             event: OSFramework.Maps.Event.Shape.ShapeEventType;
             uniqueId: string; //Event unique identifier
         }[]
     > = new Map<
         string,
         {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            cb: any;
+            cb: OSFramework.Maps.Callbacks.Generic;
             event: OSFramework.Maps.Event.Shape.ShapeEventType;
             uniqueId: string; //Event unique identifier
         }[]
@@ -96,7 +93,6 @@ namespace OutSystems.Maps.MapAPI.ShapeManager.Events {
     export function SubscribeByEventUniqueId(
         eventUniqueId: string,
         eventName: OSFramework.Maps.Event.Shape.ShapeEventType,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         callback: OSFramework.Maps.Callbacks.Shape.Event
     ): void {
         // Let's make sure that if the Map doesn't exist, we don't throw and exception but instead add the handler to the pendingEvents
@@ -206,7 +202,6 @@ namespace MapAPI.ShapeManager.Events {
     export function SubscribeByEventUniqueId(
         eventUniqueId: string,
         eventName: OSFramework.Maps.Event.Shape.ShapeEventType,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         callback: OSFramework.Maps.Callbacks.Shape.Event
     ): void {
         OSFramework.Maps.Helper.LogWarningMessage(

--- a/src/OutSystems/Maps/MapAPI/ShapeManager.ts
+++ b/src/OutSystems/Maps/MapAPI/ShapeManager.ts
@@ -14,8 +14,7 @@ namespace OutSystems.Maps.MapAPI.ShapeManager {
     export function ChangeProperty(
         shapeId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         const shape = GetShapeById(shapeId);
         const map = shape.map;
@@ -66,7 +65,6 @@ namespace OutSystems.Maps.MapAPI.ShapeManager {
         const shape = GetShapeById(
             shapeId
         ) as OSFramework.Maps.Shape.IShapeCircle;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const properties =
             new OSFramework.Maps.OSStructures.API.CircleProperties();
         if (shape.type === OSFramework.Maps.Enum.ShapeType.Circle) {
@@ -138,10 +136,10 @@ namespace OutSystems.Maps.MapAPI.ShapeManager {
             allMaps.find((map: OSFramework.Maps.OSMap.IMap) => {
                 return (shape =
                     map.drawingTools &&
-                    map.drawingTools.createdElements.find(
+                    (map.drawingTools.createdElements.find(
                         (shape: OSFramework.Maps.Shape.IShape) =>
                             shape.equalsToID(shapeId)
-                    ));
+                    ) as OSFramework.Maps.Shape.IShape));
             });
 
             // If still wasn't found, then it does not exist and throw error
@@ -229,8 +227,7 @@ namespace MapAPI.ShapeManager {
     export function ChangeProperty(
         shapeId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         OSFramework.Maps.Helper.LogWarningMessage(
             `${OSFramework.Maps.Helper.warningMessage} 'OutSystems.Maps.MapAPI.ShapeManager.ChangeProperty()'`

--- a/src/OutSystems/Maps/PlacesAPI/SearchPlacesManager.Events.ts
+++ b/src/OutSystems/Maps/PlacesAPI/SearchPlacesManager.Events.ts
@@ -1,19 +1,16 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OutSystems.Maps.PlacesAPI.SearchPlacesManager.Events {
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     const _pendingEvents: Map<
         string,
         {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            cb: any;
+            cb: OSFramework.Maps.Callbacks.Generic;
             event: OSFramework.Maps.Event.SearchPlaces.SearchPlacesEventType;
             uniqueId: string;
         }[]
     > = new Map<
         string,
         {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            cb: any;
+            cb: OSFramework.Maps.Callbacks.Generic;
             event: OSFramework.Maps.Event.SearchPlaces.SearchPlacesEventType;
             uniqueId: string;
         }[]

--- a/src/OutSystems/Maps/PlacesAPI/SearchPlacesManager.ts
+++ b/src/OutSystems/Maps/PlacesAPI/SearchPlacesManager.ts
@@ -18,8 +18,7 @@ namespace OutSystems.Maps.PlacesAPI.SearchPlacesManager {
     export function ChangeProperty(
         searchPlacesId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         const searchPlaces = GetSearchPlacesById(searchPlacesId);
 
@@ -152,8 +151,7 @@ namespace PlacesAPI.SearchPlacesManager {
     export function ChangeProperty(
         searchPlacesId: string,
         propertyName: string,
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        propertyValue: any
+        propertyValue: unknown
     ): void {
         OSFramework.Maps.Helper.LogWarningMessage(
             `${OSFramework.Maps.Helper.warningMessage} 'OutSystems.Maps.PlacesAPI.SearchPlacesManager.ChangeProperty()'`

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawBasicShapeConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawBasicShapeConfig.ts
@@ -8,9 +8,10 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
         public strokeOpacity: number;
         public strokeWeight: number;
 
-        constructor(config: JSON) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything.
+        // constructor(config: JSON) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawBasicShapeConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawBasicShapeConfig.ts
@@ -8,8 +8,7 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
         public strokeOpacity: number;
         public strokeWeight: number;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: JSON) {
             super(config);
         }
 

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawBasicShapeConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawBasicShapeConfig.ts
@@ -8,7 +8,7 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
         public strokeOpacity: number;
         public strokeWeight: number;
 
-        // No need for constructor, as it is not doing anything.
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
         // constructor(config: JSON) {
         //     super(config);
         // }

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawConfig.ts
@@ -9,9 +9,10 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
         public allowDrag: boolean;
         public uniqueId: string;
 
-        constructor(config: JSON) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything.
+        // constructor(config: JSON) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawConfig.ts
@@ -9,7 +9,7 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
         public allowDrag: boolean;
         public uniqueId: string;
 
-        // No need for constructor, as it is not doing anything.
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
         // constructor(config: JSON) {
         //     super(config);
         // }

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawConfig.ts
@@ -9,8 +9,7 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
         public allowDrag: boolean;
         public uniqueId: string;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: JSON) {
             super(config);
         }
 

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawFilledShapeConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawFilledShapeConfig.ts
@@ -6,7 +6,7 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
         public fillColor: string;
         public fillOpacity: number;
 
-        // No need for constructor, as it is not doing anything.
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
         // constructor(config: JSON) {
         //     super(config);
         // }

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawFilledShapeConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawFilledShapeConfig.ts
@@ -6,8 +6,7 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
         public fillColor: string;
         public fillOpacity: number;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: JSON) {
             super(config);
         }
 

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawFilledShapeConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawFilledShapeConfig.ts
@@ -6,9 +6,10 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
         public fillColor: string;
         public fillOpacity: number;
 
-        constructor(config: JSON) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything.
+        // constructor(config: JSON) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawMarkerConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawMarkerConfig.ts
@@ -5,7 +5,7 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
     export class DrawMarkerConfig extends DrawConfig {
         public iconUrl: string;
 
-        // No need for constructor, as it is not doing anything.
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
         // constructor(config: JSON) {
         //     super(config);
         // }

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawMarkerConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawMarkerConfig.ts
@@ -5,8 +5,7 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
     export class DrawMarkerConfig extends DrawConfig {
         public iconUrl: string;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: JSON) {
             super(config);
         }
 

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawMarkerConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawMarkerConfig.ts
@@ -5,9 +5,10 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
     export class DrawMarkerConfig extends DrawConfig {
         public iconUrl: string;
 
-        constructor(config: JSON) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything.
+        // constructor(config: JSON) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawingToolsConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawingToolsConfig.ts
@@ -6,12 +6,10 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
         extends OSFramework.Maps.Configuration.AbstractConfiguration
         implements OSFramework.Maps.Configuration.IConfigurationDrawingTools
     {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public position: string;
         public uniqueId: string;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: JSON) {
             super(config);
         }
 

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawingToolsConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawingToolsConfig.ts
@@ -9,9 +9,10 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
         public position: string;
         public uniqueId: string;
 
-        constructor(config: JSON) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything.
+        // constructor(config: JSON) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Google/Configuration/DrawingTools/DrawingToolsConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/DrawingTools/DrawingToolsConfig.ts
@@ -9,7 +9,7 @@ namespace Provider.Maps.Google.Configuration.DrawingTools {
         public position: string;
         public uniqueId: string;
 
-        // No need for constructor, as it is not doing anything.
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
         // constructor(config: JSON) {
         //     super(config);
         // }

--- a/src/Providers/Maps/Google/Configuration/FileLayer/FileLayerConfigs.ts
+++ b/src/Providers/Maps/Google/Configuration/FileLayer/FileLayerConfigs.ts
@@ -10,9 +10,10 @@ namespace Provider.Maps.Google.Configuration.FileLayer {
         public preserveViewport: boolean;
         public suppressPopups: boolean;
 
-        constructor(config: JSON) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything.
+        // constructor(config: JSON) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Google/Configuration/FileLayer/FileLayerConfigs.ts
+++ b/src/Providers/Maps/Google/Configuration/FileLayer/FileLayerConfigs.ts
@@ -6,13 +6,11 @@ namespace Provider.Maps.Google.Configuration.FileLayer {
         extends OSFramework.Maps.Configuration.AbstractConfiguration
         implements OSFramework.Maps.Configuration.IConfigurationFileLayer
     {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public layerUrl: string;
         public preserveViewport: boolean;
         public suppressPopups: boolean;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: JSON) {
             super(config);
         }
 

--- a/src/Providers/Maps/Google/Configuration/FileLayer/FileLayerConfigs.ts
+++ b/src/Providers/Maps/Google/Configuration/FileLayer/FileLayerConfigs.ts
@@ -10,7 +10,7 @@ namespace Provider.Maps.Google.Configuration.FileLayer {
         public preserveViewport: boolean;
         public suppressPopups: boolean;
 
-        // No need for constructor, as it is not doing anything.
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
         // constructor(config: JSON) {
         //     super(config);
         // }

--- a/src/Providers/Maps/Google/Configuration/HeatmapLayer/HeatmapLayerConfigs.ts
+++ b/src/Providers/Maps/Google/Configuration/HeatmapLayer/HeatmapLayerConfigs.ts
@@ -13,7 +13,7 @@ namespace Provider.Maps.Google.Configuration.HeatmapLayer {
         public points: Array<OSFramework.Maps.OSStructures.HeatmapLayer.Points>;
         public radius: number;
 
-        // No need for constructor, as it is not doing anything.
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
         // constructor(config: JSON) {
         //     super(config);
         // }

--- a/src/Providers/Maps/Google/Configuration/HeatmapLayer/HeatmapLayerConfigs.ts
+++ b/src/Providers/Maps/Google/Configuration/HeatmapLayer/HeatmapLayerConfigs.ts
@@ -13,9 +13,10 @@ namespace Provider.Maps.Google.Configuration.HeatmapLayer {
         public points: Array<OSFramework.Maps.OSStructures.HeatmapLayer.Points>;
         public radius: number;
 
-        constructor(config: JSON) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything.
+        // constructor(config: JSON) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Google/Configuration/HeatmapLayer/HeatmapLayerConfigs.ts
+++ b/src/Providers/Maps/Google/Configuration/HeatmapLayer/HeatmapLayerConfigs.ts
@@ -13,8 +13,7 @@ namespace Provider.Maps.Google.Configuration.HeatmapLayer {
         public points: Array<OSFramework.Maps.OSStructures.HeatmapLayer.Points>;
         public radius: number;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: JSON) {
             super(config);
         }
 

--- a/src/Providers/Maps/Google/Configuration/Marker/GoogleMarkerConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/Marker/GoogleMarkerConfig.ts
@@ -14,9 +14,10 @@ namespace Provider.Maps.Google.Configuration.Marker {
         public location: string;
         public title: string;
 
-        constructor(config: unknown) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
+        // constructor(config: unknown) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Google/Configuration/Marker/GoogleMarkerConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/Marker/GoogleMarkerConfig.ts
@@ -14,8 +14,7 @@ namespace Provider.Maps.Google.Configuration.Marker {
         public location: string;
         public title: string;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: unknown) {
             super(config);
         }
 

--- a/src/Providers/Maps/Google/Configuration/MarkerClusterer/MarkerClustererConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/MarkerClusterer/MarkerClustererConfig.ts
@@ -11,8 +11,9 @@ namespace Provider.Maps.Google.Configuration.MarkerClusterer {
         public markerClustererZoomOnClick: boolean;
         public styles: Array<OSFramework.Maps.OSStructures.Clusterer.Style>;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(
+            config: OSFramework.Maps.Configuration.IConfigurationMarkerClusterer
+        ) {
             super(config);
         }
 

--- a/src/Providers/Maps/Google/Configuration/MarkerClusterer/MarkerClustererConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/MarkerClusterer/MarkerClustererConfig.ts
@@ -11,11 +11,12 @@ namespace Provider.Maps.Google.Configuration.MarkerClusterer {
         public markerClustererZoomOnClick: boolean;
         public styles: Array<OSFramework.Maps.OSStructures.Clusterer.Style>;
 
-        constructor(
-            config: OSFramework.Maps.Configuration.IConfigurationMarkerClusterer
-        ) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
+        // constructor(
+        //     config: OSFramework.Maps.Configuration.IConfigurationMarkerClusterer
+        // ) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Google/Configuration/OSMap/GoogleMapConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/OSMap/GoogleMapConfig.ts
@@ -16,9 +16,10 @@ namespace Provider.Maps.Google.Configuration.OSMap {
         public uniqueId: string;
         public zoom: OSFramework.Maps.Enum.OSMap.Zoom;
 
-        constructor(config: JSON) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything.
+        // constructor(config: JSON) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Google/Configuration/OSMap/GoogleMapConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/OSMap/GoogleMapConfig.ts
@@ -16,8 +16,7 @@ namespace Provider.Maps.Google.Configuration.OSMap {
         public uniqueId: string;
         public zoom: OSFramework.Maps.Enum.OSMap.Zoom;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: JSON) {
             super(config);
         }
 

--- a/src/Providers/Maps/Google/Configuration/OSMap/GoogleMapConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/OSMap/GoogleMapConfig.ts
@@ -16,7 +16,7 @@ namespace Provider.Maps.Google.Configuration.OSMap {
         public uniqueId: string;
         public zoom: OSFramework.Maps.Enum.OSMap.Zoom;
 
-        // No need for constructor, as it is not doing anything.
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
         // constructor(config: JSON) {
         //     super(config);
         // }

--- a/src/Providers/Maps/Google/Configuration/OSMap/GoogleStaticMapConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/OSMap/GoogleStaticMapConfig.ts
@@ -11,7 +11,7 @@ namespace Provider.Maps.Google.Configuration.OSMap {
         public uniqueId: string;
         public zoom: OSFramework.Maps.Enum.OSMap.Zoom;
 
-        // No need for constructor, as it is not doing anything.
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
         // constructor(config: JSON) {
         //     super(config);
         // }

--- a/src/Providers/Maps/Google/Configuration/OSMap/GoogleStaticMapConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/OSMap/GoogleStaticMapConfig.ts
@@ -11,8 +11,7 @@ namespace Provider.Maps.Google.Configuration.OSMap {
         public uniqueId: string;
         public zoom: OSFramework.Maps.Enum.OSMap.Zoom;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: JSON) {
             super(config);
         }
 

--- a/src/Providers/Maps/Google/Configuration/OSMap/GoogleStaticMapConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/OSMap/GoogleStaticMapConfig.ts
@@ -11,9 +11,10 @@ namespace Provider.Maps.Google.Configuration.OSMap {
         public uniqueId: string;
         public zoom: OSFramework.Maps.Enum.OSMap.Zoom;
 
-        constructor(config: JSON) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything.
+        // constructor(config: JSON) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Google/Configuration/SearchPlaces/ISearchPlacesProviderConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/SearchPlaces/ISearchPlacesProviderConfig.ts
@@ -1,0 +1,9 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace Provider.Maps.Google.Configuration.SearchPlaces {
+    export interface ISearchPlacesProviderConfig {
+        bounds?: OSFramework.Maps.OSStructures.OSMap.BoundsString;
+        componentRestrictions: { country: string[] };
+        strictBounds?: boolean;
+        types: [Google.SearchPlaces.SearchTypes];
+    }
+}

--- a/src/Providers/Maps/Google/Configuration/SearchPlaces/SearchPlacesConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/SearchPlaces/SearchPlacesConfig.ts
@@ -11,7 +11,7 @@ namespace Provider.Maps.Google.Configuration.SearchPlaces {
         public searchArea: OSFramework.Maps.OSStructures.OSMap.BoundsString;
         public searchType: OSFramework.Maps.Enum.SearchTypes;
 
-        // No need for constructor, as it is not doing anything.
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
         // constructor(config: JSON) {
         //     super(config);
         // }

--- a/src/Providers/Maps/Google/Configuration/SearchPlaces/SearchPlacesConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/SearchPlaces/SearchPlacesConfig.ts
@@ -11,9 +11,10 @@ namespace Provider.Maps.Google.Configuration.SearchPlaces {
         public searchArea: OSFramework.Maps.OSStructures.OSMap.BoundsString;
         public searchType: OSFramework.Maps.Enum.SearchTypes;
 
-        constructor(config: JSON) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything.
+        // constructor(config: JSON) {
+        //     super(config);
+        // }
 
         public getProviderConfig(): ISearchPlacesProviderConfig {
             // eslint-disable-next-line prefer-const

--- a/src/Providers/Maps/Google/Configuration/SearchPlaces/SearchPlacesConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/SearchPlaces/SearchPlacesConfig.ts
@@ -11,15 +11,13 @@ namespace Provider.Maps.Google.Configuration.SearchPlaces {
         public searchArea: OSFramework.Maps.OSStructures.OSMap.BoundsString;
         public searchType: OSFramework.Maps.Enum.SearchTypes;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: JSON) {
             super(config);
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public getProviderConfig(): any {
+        public getProviderConfig(): ISearchPlacesProviderConfig {
             // eslint-disable-next-line prefer-const
-            let provider = {
+            let provider: ISearchPlacesProviderConfig = {
                 bounds: this.searchArea,
                 strictBounds: !!this.searchArea,
                 componentRestrictions: this.countries

--- a/src/Providers/Maps/Google/Configuration/Shape/BasicShapeConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/Shape/BasicShapeConfig.ts
@@ -14,9 +14,10 @@ namespace Provider.Maps.Google.Configuration.Shape {
         public strokeWeight: number;
         public uniqueId: string;
 
-        constructor(config: unknown) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
+        // constructor(config: unknown) {
+        //     super(config);
+        // }
 
         public getProviderConfig(): IShapeProviderConfig {
             // eslint-disable-next-line prefer-const

--- a/src/Providers/Maps/Google/Configuration/Shape/BasicShapeConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/Shape/BasicShapeConfig.ts
@@ -14,20 +14,18 @@ namespace Provider.Maps.Google.Configuration.Shape {
         public strokeWeight: number;
         public uniqueId: string;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: unknown) {
             super(config);
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public getProviderConfig(): any {
+        public getProviderConfig(): IShapeProviderConfig {
             // eslint-disable-next-line prefer-const
-            let provider = {
+            let provider: IShapeProviderConfig = {
                 clickable: true,
                 draggable: this.allowDrag,
                 editable: this.allowEdit,
-                strokeOpacity: this.strokeOpacity,
                 strokeColor: this.strokeColor,
+                strokeOpacity: this.strokeOpacity,
                 strokeWeight: this.strokeWeight
             };
 

--- a/src/Providers/Maps/Google/Configuration/Shape/CircleShapeConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/Shape/CircleShapeConfig.ts
@@ -6,9 +6,10 @@ namespace Provider.Maps.Google.Configuration.Shape {
         public center: string;
         public radius: number;
 
-        constructor(config: unknown) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
+        // constructor(config: unknown) {
+        //     super(config);
+        // }
 
         public getProviderConfig(): IShapeProviderConfig {
             const provider = super.getProviderConfig();

--- a/src/Providers/Maps/Google/Configuration/Shape/CircleShapeConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/Shape/CircleShapeConfig.ts
@@ -6,13 +6,11 @@ namespace Provider.Maps.Google.Configuration.Shape {
         public center: string;
         public radius: number;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: unknown) {
             super(config);
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public getProviderConfig(): any {
+        public getProviderConfig(): IShapeProviderConfig {
             const provider = super.getProviderConfig();
             provider.radius = this.radius;
 

--- a/src/Providers/Maps/Google/Configuration/Shape/FilledShapeConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/Shape/FilledShapeConfig.ts
@@ -6,18 +6,16 @@ namespace Provider.Maps.Google.Configuration.Shape {
         public fillColor: string;
         public fillOpacity: number;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: unknown) {
             super(config);
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public getProviderConfig(): any {
-            const provider = super.getProviderConfig();
-            provider.fillColor = this.fillColor;
-            provider.fillOpacity = this.fillOpacity;
+        public getProviderConfig(): IShapeProviderConfig {
+            const provider_configs = super.getProviderConfig();
+            provider_configs.fillColor = this.fillColor;
+            provider_configs.fillOpacity = this.fillOpacity;
 
-            return provider;
+            return provider_configs;
         }
     }
 }

--- a/src/Providers/Maps/Google/Configuration/Shape/FilledShapeConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/Shape/FilledShapeConfig.ts
@@ -6,9 +6,10 @@ namespace Provider.Maps.Google.Configuration.Shape {
         public fillColor: string;
         public fillOpacity: number;
 
-        constructor(config: unknown) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
+        // constructor(config: unknown) {
+        //     super(config);
+        // }
 
         public getProviderConfig(): IShapeProviderConfig {
             const provider_configs = super.getProviderConfig();

--- a/src/Providers/Maps/Google/Configuration/Shape/IShapeProviderConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/Shape/IShapeProviderConfig.ts
@@ -1,0 +1,15 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace Provider.Maps.Google.Configuration.Shape {
+    export interface IShapeProviderConfig {
+        clickable: boolean;
+        draggable: boolean;
+        editable: boolean;
+        fillColor?: string;
+        fillOpacity?: number;
+        locations?: string;
+        radius?: number;
+        strokeColor: string;
+        strokeOpacity: number;
+        strokeWeight: number;
+    }
+}

--- a/src/Providers/Maps/Google/Configuration/Shape/RectangleShapeConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/Shape/RectangleShapeConfig.ts
@@ -5,13 +5,11 @@ namespace Provider.Maps.Google.Configuration.Shape {
     export class RectangleShapeConfig extends FilledShapeConfig {
         public bounds: string;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: unknown) {
             super(config);
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public getProviderConfig(): any {
+        public getProviderConfig(): IShapeProviderConfig {
             const provider = super.getProviderConfig();
 
             // Rectangle doesn't have locations on its configurations

--- a/src/Providers/Maps/Google/Configuration/Shape/RectangleShapeConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/Shape/RectangleShapeConfig.ts
@@ -5,9 +5,10 @@ namespace Provider.Maps.Google.Configuration.Shape {
     export class RectangleShapeConfig extends FilledShapeConfig {
         public bounds: string;
 
-        constructor(config: unknown) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
+        // constructor(config: unknown) {
+        //     super(config);
+        // }
 
         public getProviderConfig(): IShapeProviderConfig {
             const provider = super.getProviderConfig();

--- a/src/Providers/Maps/Google/DrawingTools/AbstractDrawPolyshape.ts
+++ b/src/Providers/Maps/Google/DrawingTools/AbstractDrawPolyshape.ts
@@ -13,8 +13,7 @@ namespace Provider.Maps.Google.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             drawingToolsId: string,
             type: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: W
         ) {
             super(map, drawingTools, drawingToolsId, type, configs);
         }

--- a/src/Providers/Maps/Google/DrawingTools/AbstractDrawShape.ts
+++ b/src/Providers/Maps/Google/DrawingTools/AbstractDrawShape.ts
@@ -10,8 +10,7 @@ namespace Provider.Maps.Google.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             drawingToolsId: string,
             type: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: T
         ) {
             super(map, drawingTools, drawingToolsId, type, configs);
         }
@@ -55,8 +54,7 @@ namespace Provider.Maps.Google.DrawingTools {
         protected createShapeElement(
             uniqueId: string,
             type: OSFramework.Maps.Enum.ShapeType,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: unknown
         ): OSFramework.Maps.Shape.IShape {
             const _shape = Shape.ShapeFactory.MakeShape(
                 this.map,

--- a/src/Providers/Maps/Google/DrawingTools/AbstractProviderTool.ts
+++ b/src/Providers/Maps/Google/DrawingTools/AbstractProviderTool.ts
@@ -11,8 +11,7 @@ namespace Provider.Maps.Google.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             drawingToolsId: string,
             type: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: T
         ) {
             super(map, drawingTools, drawingToolsId, type, configs);
         }
@@ -103,12 +102,10 @@ namespace Provider.Maps.Google.DrawingTools {
             super.dispose();
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public abstract get options(): any;
+        public abstract get options(): unknown;
         protected abstract get completedToolEventName(): string;
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        protected abstract set options(options: any);
+        protected abstract set options(options: unknown);
 
         /**
          * Creates a new element based on the new element provider that results from the marker or shape complete events.

--- a/src/Providers/Maps/Google/DrawingTools/DrawCircle.ts
+++ b/src/Providers/Maps/Google/DrawingTools/DrawCircle.ts
@@ -22,6 +22,7 @@ namespace Provider.Maps.Google.DrawingTools {
         private _createConfigsElement(
             shape: google.maps.Circle,
             configs: Configuration.Shape.CircleShapeConfig
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ): any {
             const providerCenter = shape.getCenter();
             const center = `${providerCenter.lat()},${providerCenter.lng()}`;

--- a/src/Providers/Maps/Google/DrawingTools/DrawCircle.ts
+++ b/src/Providers/Maps/Google/DrawingTools/DrawCircle.ts
@@ -8,8 +8,7 @@ namespace Provider.Maps.Google.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             drawingToolsId: string,
             type: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: JSON
         ) {
             super(
                 map,
@@ -22,9 +21,7 @@ namespace Provider.Maps.Google.DrawingTools {
 
         private _createConfigsElement(
             shape: google.maps.Circle,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
             configs: Configuration.Shape.CircleShapeConfig
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ): any {
             const providerCenter = shape.getCenter();
             const center = `${providerCenter.lat()},${providerCenter.lng()}`;
@@ -58,7 +55,6 @@ namespace Provider.Maps.Google.DrawingTools {
         protected createElement(
             uniqueId: string,
             shape: google.maps.Circle,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
             configs: Configuration.Shape.CircleShapeConfig
         ): OSFramework.Maps.Shape.IShape {
             // we need to clean the provided configs and add the locations in order to create the new element

--- a/src/Providers/Maps/Google/DrawingTools/DrawMarker.ts
+++ b/src/Providers/Maps/Google/DrawingTools/DrawMarker.ts
@@ -65,8 +65,7 @@ namespace Provider.Maps.Google.DrawingTools {
         protected createElement(
             uniqueId: string,
             marker: google.maps.Marker,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: unknown[]
         ): OSFramework.Maps.Marker.IMarker {
             const location = `${marker.getPosition().lat()},${marker
                 .getPosition()

--- a/src/Providers/Maps/Google/DrawingTools/DrawPolygon.ts
+++ b/src/Providers/Maps/Google/DrawingTools/DrawPolygon.ts
@@ -8,8 +8,7 @@ namespace Provider.Maps.Google.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             drawingToolsId: string,
             type: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: JSON
         ) {
             super(
                 map,

--- a/src/Providers/Maps/Google/DrawingTools/DrawPolyline.ts
+++ b/src/Providers/Maps/Google/DrawingTools/DrawPolyline.ts
@@ -8,8 +8,7 @@ namespace Provider.Maps.Google.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             drawingToolsId: string,
             type: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: JSON
         ) {
             super(
                 map,

--- a/src/Providers/Maps/Google/DrawingTools/DrawRectangle.ts
+++ b/src/Providers/Maps/Google/DrawingTools/DrawRectangle.ts
@@ -8,8 +8,7 @@ namespace Provider.Maps.Google.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             drawingToolsId: string,
             type: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: JSON
         ) {
             super(
                 map,

--- a/src/Providers/Maps/Google/DrawingTools/DrawingTools.ts
+++ b/src/Providers/Maps/Google/DrawingTools/DrawingTools.ts
@@ -11,8 +11,7 @@ namespace Provider.Maps.Google.DrawingTools {
         constructor(
             map: OSFramework.Maps.OSMap.IMap,
             drawingToolsId: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: JSON
         ) {
             super(
                 map,

--- a/src/Providers/Maps/Google/DrawingTools/Factory.ts
+++ b/src/Providers/Maps/Google/DrawingTools/Factory.ts
@@ -4,14 +4,9 @@ namespace Provider.Maps.Google.DrawingTools {
         export function MakeDrawingTools(
             map: OSFramework.Maps.OSMap.IMap,
             drawingToolsId: string,
-            configs: OSFramework.Maps.Configuration.IConfiguration
+            configs: JSON
         ): OSFramework.Maps.DrawingTools.IDrawingTools {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            return new DrawingTools(
-                map,
-                drawingToolsId,
-                configs as Configuration.DrawingTools.DrawingToolsConfig
-            );
+            return new DrawingTools(map, drawingToolsId, configs);
         }
 
         export function MakeTool(
@@ -19,9 +14,8 @@ namespace Provider.Maps.Google.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             toolId: string,
             type: OSFramework.Maps.Enum.DrawingToolsTypes,
-            configs: OSFramework.Maps.Configuration.IConfiguration
+            configs: JSON
         ): OSFramework.Maps.DrawingTools.ITool {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             switch (type) {
                 case OSFramework.Maps.Enum.DrawingToolsTypes.Marker:
                     return new DrawMarker(
@@ -29,7 +23,7 @@ namespace Provider.Maps.Google.DrawingTools {
                         drawingTools,
                         toolId,
                         type,
-                        configs as Configuration.DrawingTools.DrawMarkerConfig
+                        configs
                     );
                 case OSFramework.Maps.Enum.DrawingToolsTypes.Polyline:
                     return new DrawPolyline(
@@ -37,7 +31,7 @@ namespace Provider.Maps.Google.DrawingTools {
                         drawingTools,
                         toolId,
                         type,
-                        configs as Configuration.DrawingTools.DrawBasicShapeConfig
+                        configs
                     );
                 case OSFramework.Maps.Enum.DrawingToolsTypes.Polygon:
                     return new DrawPolygon(
@@ -45,7 +39,7 @@ namespace Provider.Maps.Google.DrawingTools {
                         drawingTools,
                         toolId,
                         type,
-                        configs as Configuration.DrawingTools.DrawFilledShapeConfig
+                        configs
                     );
                 case OSFramework.Maps.Enum.DrawingToolsTypes.Circle:
                     return new DrawCircle(
@@ -53,7 +47,7 @@ namespace Provider.Maps.Google.DrawingTools {
                         drawingTools,
                         toolId,
                         type,
-                        configs as Configuration.DrawingTools.DrawFilledShapeConfig
+                        configs
                     );
                 case OSFramework.Maps.Enum.DrawingToolsTypes.Rectangle:
                     return new DrawRectangle(
@@ -61,7 +55,7 @@ namespace Provider.Maps.Google.DrawingTools {
                         drawingTools,
                         toolId,
                         type,
-                        configs as Configuration.DrawingTools.DrawFilledShapeConfig
+                        configs
                     );
                 default:
                     throw new Error(

--- a/src/Providers/Maps/Google/Features/Center.ts
+++ b/src/Providers/Maps/Google/Features/Center.ts
@@ -21,6 +21,17 @@ namespace Provider.Maps.Google.Feature {
             this._initialCenter = center;
         }
 
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        public build(): void {}
+
+        public getCenter(): OSFramework.Maps.OSStructures.OSMap.Coordinates {
+            return this._initialCenter;
+        }
+
+        public getCurrentCenter(): OSFramework.Maps.OSStructures.OSMap.Coordinates {
+            return this._currentCenter;
+        }
+
         public getMapCenter(): OSFramework.Maps.OSStructures.ReturnMessage {
             // Set the default return message
             const responseObj = {
@@ -47,17 +58,6 @@ namespace Provider.Maps.Google.Feature {
             }
 
             return responseObj;
-        }
-
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        public build(): void {}
-
-        public getCenter(): OSFramework.Maps.OSStructures.OSMap.Coordinates {
-            return this._initialCenter;
-        }
-
-        public getCurrentCenter(): OSFramework.Maps.OSStructures.OSMap.Coordinates {
-            return this._currentCenter;
         }
 
         public refreshCenter(

--- a/src/Providers/Maps/Google/Features/FeatureBuilder.ts
+++ b/src/Providers/Maps/Google/Features/FeatureBuilder.ts
@@ -18,7 +18,7 @@ namespace Provider.Maps.Google.Feature {
             this._features = new OSFramework.Maps.Feature.ExposedFeatures();
         }
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-explicit-any
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         private _instanceOfIDisposable(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             object: any
@@ -27,10 +27,8 @@ namespace Provider.Maps.Google.Feature {
         }
 
         protected _makeItem<T extends OSFramework.Maps.Interface.IBuilder>(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            c: new (...args: any) => T,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-            ...args
+            c: new (...args: unknown[]) => T,
+            ...args: unknown[]
         ): T {
             const o = new c(this._map, ...args);
             this._featureList.push(o);

--- a/src/Providers/Maps/Google/Features/GoogleMarkerClusterer.ts
+++ b/src/Providers/Maps/Google/Features/GoogleMarkerClusterer.ts
@@ -41,7 +41,9 @@ namespace Provider.Maps.Google.Feature {
             );
 
             if (value === true) {
-                this._markerClusterer.addMarkers(this._map.markersReady);
+                this._markerClusterer.addMarkers(
+                    this._map.markersReady as google.maps.Marker[]
+                );
             } else {
                 this._markerClusterer.clearMarkers();
                 this._map.markers.forEach((marker) =>
@@ -77,8 +79,7 @@ namespace Provider.Maps.Google.Feature {
 
         public changeProperty(
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_MarkerClusterer[propertyName];
@@ -99,21 +100,25 @@ namespace Provider.Maps.Google.Feature {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_MarkerClusterer
                         .markerClustererActive:
-                        this._setState(propertyValue);
+                        this._setState(propertyValue as boolean);
                         break;
                     case OSFramework.Maps.Enum.OS_Config_MarkerClusterer
                         .markerClustererMinClusterSize:
                         this._markerClusterer.setMinimumClusterSize(
-                            propertyValue
+                            propertyValue as number
                         );
                         break;
                     case OSFramework.Maps.Enum.OS_Config_MarkerClusterer
                         .markerClustererMaxZoom:
-                        this._markerClusterer.setMaxZoom(propertyValue);
+                        this._markerClusterer.setMaxZoom(
+                            propertyValue as number
+                        );
                         break;
                     case OSFramework.Maps.Enum.OS_Config_MarkerClusterer
                         .markerClustererZoomOnClick:
-                        this._markerClusterer.setZoomOnClick(propertyValue);
+                        this._markerClusterer.setZoomOnClick(
+                            propertyValue as boolean
+                        );
                         break;
                 }
                 this.repaint();

--- a/src/Providers/Maps/Google/FileLayer/Factory.ts
+++ b/src/Providers/Maps/Google/FileLayer/Factory.ts
@@ -4,14 +4,9 @@ namespace Provider.Maps.Google.FileLayer {
         export function MakeFileLayer(
             map: OSFramework.Maps.OSMap.IMap,
             fileLayerId: string,
-            configs: OSFramework.Maps.Configuration.IConfiguration
+            configs: JSON
         ): OSFramework.Maps.FileLayer.IFileLayer {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            return new FileLayer(
-                map,
-                fileLayerId,
-                configs as Configuration.FileLayer.FileLayerConfig
-            );
+            return new FileLayer(map, fileLayerId, configs);
         }
     }
 }

--- a/src/Providers/Maps/Google/FileLayer/FileLayer.ts
+++ b/src/Providers/Maps/Google/FileLayer/FileLayer.ts
@@ -9,8 +9,7 @@ namespace Provider.Maps.Google.FileLayer {
         constructor(
             map: OSFramework.Maps.OSMap.IMap,
             FileLayerId: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: JSON
         ) {
             super(
                 map,

--- a/src/Providers/Maps/Google/HeatmapLayer/Factory.ts
+++ b/src/Providers/Maps/Google/HeatmapLayer/Factory.ts
@@ -4,14 +4,9 @@ namespace Provider.Maps.Google.HeatmapLayer {
         export function MakeHeatmapLayer(
             map: OSFramework.Maps.OSMap.IMap,
             heatmapLayerId: string,
-            configs: OSFramework.Maps.Configuration.IConfiguration
+            configs: JSON
         ): OSFramework.Maps.HeatmapLayer.IHeatmapLayer {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            return new HeatmapLayer(
-                map,
-                heatmapLayerId,
-                configs as Configuration.HeatmapLayer.HeatmapLayerConfig
-            );
+            return new HeatmapLayer(map, heatmapLayerId, configs);
         }
     }
 }

--- a/src/Providers/Maps/Google/HeatmapLayer/HeatmapLayer.ts
+++ b/src/Providers/Maps/Google/HeatmapLayer/HeatmapLayer.ts
@@ -14,8 +14,7 @@ namespace Provider.Maps.Google.HeatmapLayer {
         constructor(
             map: OSFramework.Maps.OSMap.IMap,
             HeatmapLayerId: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: JSON
         ) {
             super(
                 map,

--- a/src/Providers/Maps/Google/Marker/Factory.ts
+++ b/src/Providers/Maps/Google/Marker/Factory.ts
@@ -5,7 +5,7 @@ namespace Provider.Maps.Google.Marker {
             map: OSFramework.Maps.OSMap.IMap,
             markerId: string,
             type: OSFramework.Maps.Enum.MarkerType,
-            configs: Configuration.Marker.GoogleMarkerConfig
+            configs: unknown
         ): OSFramework.Maps.Marker.IMarker {
             switch (type) {
                 case OSFramework.Maps.Enum.MarkerType.Marker:

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -223,15 +223,18 @@ namespace Provider.Maps.Google.Marker {
             }
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Marker[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Marker.location:
                         Helper.Conversions.ConvertToCoordinates(
-                            value as string,
+                            propertyValue as string,
                             this.map.config.apiKey
                         )
                             .then((response) => {
@@ -253,18 +256,20 @@ namespace Provider.Maps.Google.Marker {
                             });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.allowDrag:
-                        return this._provider.setDraggable(value as boolean);
+                        return this._provider.setDraggable(
+                            propertyValue as boolean
+                        );
                     case OSFramework.Maps.Enum.OS_Config_Marker.iconHeight:
                     case OSFramework.Maps.Enum.OS_Config_Marker.iconWidth:
                         this._setIconSize();
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.iconUrl:
-                        this._setIcon(value as string);
+                        this._setIcon(propertyValue as string);
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.label:
-                        return this._provider.setLabel(value as string);
+                        return this._provider.setLabel(propertyValue as string);
                     case OSFramework.Maps.Enum.OS_Config_Marker.title:
-                        return this._provider.setTitle(value as string);
+                        return this._provider.setTitle(propertyValue as string);
                 }
             }
         }

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -15,8 +15,7 @@ namespace Provider.Maps.Google.Marker {
             map: OSFramework.Maps.OSMap.IMap,
             markerId: string,
             type: OSFramework.Maps.Enum.MarkerType,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: unknown
         ) {
             super(
                 map,
@@ -195,7 +194,7 @@ namespace Provider.Maps.Google.Marker {
                 markerPosition
                     .then((markerOptions) => {
                         this._provider = new google.maps.Marker({
-                            ...this.getProviderConfig(),
+                            ...(this.getProviderConfig() as unknown[]),
                             ...markerOptions,
                             map: this.map.provider
                         });
@@ -224,8 +223,7 @@ namespace Provider.Maps.Google.Marker {
             }
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Marker[propertyName];
             super.changeProperty(propertyName, value);
@@ -233,7 +231,7 @@ namespace Provider.Maps.Google.Marker {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Marker.location:
                         Helper.Conversions.ConvertToCoordinates(
-                            value,
+                            value as string,
                             this.map.config.apiKey
                         )
                             .then((response) => {
@@ -255,18 +253,18 @@ namespace Provider.Maps.Google.Marker {
                             });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.allowDrag:
-                        return this._provider.setDraggable(value);
+                        return this._provider.setDraggable(value as boolean);
                     case OSFramework.Maps.Enum.OS_Config_Marker.iconHeight:
                     case OSFramework.Maps.Enum.OS_Config_Marker.iconWidth:
                         this._setIconSize();
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.iconUrl:
-                        this._setIcon(value);
+                        this._setIcon(value as string);
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.label:
-                        return this._provider.setLabel(value);
+                        return this._provider.setLabel(value as string);
                     case OSFramework.Maps.Enum.OS_Config_Marker.title:
-                        return this._provider.setTitle(value);
+                        return this._provider.setTitle(value as string);
                 }
             }
         }

--- a/src/Providers/Maps/Google/OSMap/Factory.ts
+++ b/src/Providers/Maps/Google/OSMap/Factory.ts
@@ -4,19 +4,13 @@ namespace Provider.Maps.Google.OSMap {
         export function MakeMap(
             type: OSFramework.Maps.Enum.MapType,
             mapdId: string,
-            configs: OSFramework.Maps.Configuration.IConfiguration
+            configs: JSON
         ): OSFramework.Maps.OSMap.IMap {
             switch (type) {
                 case OSFramework.Maps.Enum.MapType.Map:
-                    return new Map(
-                        mapdId,
-                        configs as Configuration.OSMap.GoogleMapConfig
-                    );
+                    return new Map(mapdId, configs);
                 case OSFramework.Maps.Enum.MapType.StaticMap:
-                    return new StaticMap(
-                        mapdId,
-                        configs as Configuration.OSMap.GoogleStaticMapConfig
-                    );
+                    return new StaticMap(mapdId, configs);
                 default:
                     throw new Error(
                         `There is no factory for this type of Map (${type})`

--- a/src/Providers/Maps/Google/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Google/OSMap/OSMap.ts
@@ -15,8 +15,7 @@ namespace Provider.Maps.Google.OSMap {
         private _fBuilder: Feature.FeatureBuilder;
         private _scriptCallback: OSFramework.Maps.Callbacks.Generic;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(mapId: string, configs: any) {
+        constructor(mapId: string, configs: JSON) {
             super(
                 mapId,
                 OSFramework.Maps.Enum.ProviderType.Google,
@@ -288,8 +287,7 @@ namespace Provider.Maps.Google.OSMap {
         public changeDrawingToolsProperty(
             drawingToolsId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void {
             // There is only one (max) drawingTools element per map
             const drawingTools = this.drawingTools;
@@ -309,8 +307,7 @@ namespace Provider.Maps.Google.OSMap {
         public changeFileLayerProperty(
             fileLayerId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void {
             // There is only one (max) drawingTools element per map
             const fileLayer = this.getFileLayer(fileLayerId);
@@ -327,8 +324,7 @@ namespace Provider.Maps.Google.OSMap {
         public changeHeatmapLayerProperty(
             heatmapLayerId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void {
             const heatmapLayer = this.getHeatmapLayer(heatmapLayerId);
 
@@ -344,8 +340,7 @@ namespace Provider.Maps.Google.OSMap {
         public changeMarkerProperty(
             markerId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void {
             const marker = this.getMarker(markerId);
 
@@ -358,8 +353,7 @@ namespace Provider.Maps.Google.OSMap {
             }
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const propValue = OSFramework.Maps.Enum.OS_Config_Map[propertyName];
             super.changeProperty(propertyName, value);
             if (this.isReady) {
@@ -376,26 +370,38 @@ namespace Provider.Maps.Google.OSMap {
                         }
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Map.center:
-                        return this.features.center.updateCenter(value);
+                        return this.features.center.updateCenter(
+                            value as string
+                        );
                     case OSFramework.Maps.Enum.OS_Config_Map.offset:
                         return this.features.offset.setOffset(
-                            JSON.parse(value)
+                            JSON.parse(value as string)
                         );
                     case OSFramework.Maps.Enum.OS_Config_Map.zoom:
-                        return this.features.zoom.setLevel(value);
+                        return this.features.zoom.setLevel(
+                            value as OSFramework.Maps.Enum.OSMap.Zoom
+                        );
                     case OSFramework.Maps.Enum.OS_Config_Map.type:
-                        return this._provider.setMapTypeId(value);
+                        return this._provider.setMapTypeId(value as string);
                     case OSFramework.Maps.Enum.OS_Config_Map.style:
                         return this._provider.setOptions({
-                            styles: GetStyleByStyleId(value)
+                            styles: GetStyleByStyleId(value as number)
                         });
                     case OSFramework.Maps.Enum.OS_Config_Map.advancedFormat:
-                        value = OSFramework.Maps.Helper.JsonFormatter(value);
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        value = OSFramework.Maps.Helper.JsonFormatter(
+                            value as string
+                        );
                         // Make sure the MapEvents that are associated in the advancedFormat get updated
-                        this._setMapEvents(value.mapEvents);
+                        this._setMapEvents(
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            (value as any).mapEvents as string[]
+                        );
                         return this._provider.setOptions(value);
                     case OSFramework.Maps.Enum.OS_Config_Map.showTraffic:
-                        return this.features.trafficLayer.setState(value);
+                        return this.features.trafficLayer.setState(
+                            value as boolean
+                        );
                     case OSFramework.Maps.Enum.OS_Config_Map
                         .markerClustererActive:
                     case OSFramework.Maps.Enum.OS_Config_Map
@@ -415,8 +421,7 @@ namespace Provider.Maps.Google.OSMap {
         public changeShapeProperty(
             shapeId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void {
             const shape = this.getShape(shapeId);
 

--- a/src/Providers/Maps/Google/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Google/OSMap/OSMap.ts
@@ -353,9 +353,12 @@ namespace Provider.Maps.Google.OSMap {
             }
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const propValue = OSFramework.Maps.Enum.OS_Config_Map[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Map.apiKey:
@@ -371,36 +374,38 @@ namespace Provider.Maps.Google.OSMap {
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Map.center:
                         return this.features.center.updateCenter(
-                            value as string
+                            propertyValue as string
                         );
                     case OSFramework.Maps.Enum.OS_Config_Map.offset:
                         return this.features.offset.setOffset(
-                            JSON.parse(value as string)
+                            JSON.parse(propertyValue as string)
                         );
                     case OSFramework.Maps.Enum.OS_Config_Map.zoom:
                         return this.features.zoom.setLevel(
-                            value as OSFramework.Maps.Enum.OSMap.Zoom
+                            propertyValue as OSFramework.Maps.Enum.OSMap.Zoom
                         );
                     case OSFramework.Maps.Enum.OS_Config_Map.type:
-                        return this._provider.setMapTypeId(value as string);
+                        return this._provider.setMapTypeId(
+                            propertyValue as string
+                        );
                     case OSFramework.Maps.Enum.OS_Config_Map.style:
                         return this._provider.setOptions({
-                            styles: GetStyleByStyleId(value as number)
+                            styles: GetStyleByStyleId(propertyValue as number)
                         });
                     case OSFramework.Maps.Enum.OS_Config_Map.advancedFormat:
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        value = OSFramework.Maps.Helper.JsonFormatter(
-                            value as string
+                        propertyValue = OSFramework.Maps.Helper.JsonFormatter(
+                            propertyValue as string
                         );
                         // Make sure the MapEvents that are associated in the advancedFormat get updated
                         this._setMapEvents(
                             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                            (value as any).mapEvents as string[]
+                            (propertyValue as any).mapEvents as string[]
                         );
-                        return this._provider.setOptions(value);
+                        return this._provider.setOptions(propertyValue);
                     case OSFramework.Maps.Enum.OS_Config_Map.showTraffic:
                         return this.features.trafficLayer.setState(
-                            value as boolean
+                            propertyValue as boolean
                         );
                     case OSFramework.Maps.Enum.OS_Config_Map
                         .markerClustererActive:
@@ -412,7 +417,7 @@ namespace Provider.Maps.Google.OSMap {
                         .markerClustererZoomOnClick:
                         return this.features.markerClusterer.changeProperty(
                             propertyName,
-                            value
+                            propertyValue
                         );
                 }
             }

--- a/src/Providers/Maps/Google/OSMap/StaticMap.ts
+++ b/src/Providers/Maps/Google/OSMap/StaticMap.ts
@@ -19,8 +19,7 @@ namespace Provider.Maps.Google.OSMap {
         private _size: Size;
         private _type: OSFramework.Maps.Enum.OSMap.Type;
         private _zoom: number;
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(mapId: string, configs: any) {
+        constructor(mapId: string, configs: JSON) {
             super(
                 mapId,
                 OSFramework.Maps.Enum.ProviderType.Google,
@@ -153,7 +152,8 @@ namespace Provider.Maps.Google.OSMap {
                 this.mapEvents.trigger(
                     OSFramework.Maps.Event.OSMap.MapEventType.OnError,
                     this,
-                    OSFramework.Maps.Enum.ErrorCodes.CFG_CantChangeParamsStaticMap
+                    OSFramework.Maps.Enum.ErrorCodes
+                        .CFG_CantChangeParamsStaticMap
                 );
                 return;
             }
@@ -181,8 +181,8 @@ namespace Provider.Maps.Google.OSMap {
             drawingToolsId: string,
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            propertyValue: unknown
         ): void {
             this.mapEvents.trigger(
                 OSFramework.Maps.Event.OSMap.MapEventType.OnError,
@@ -198,8 +198,8 @@ namespace Provider.Maps.Google.OSMap {
             fileLayerId: string,
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            propertyValue: unknown
         ): void {
             this.mapEvents.trigger(
                 OSFramework.Maps.Event.OSMap.MapEventType.OnError,
@@ -215,8 +215,8 @@ namespace Provider.Maps.Google.OSMap {
             heatmapLayerId: string,
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            propertyValue: unknown
         ): void {
             this.mapEvents.trigger(
                 OSFramework.Maps.Event.OSMap.MapEventType.OnError,
@@ -232,8 +232,8 @@ namespace Provider.Maps.Google.OSMap {
             markerId: string,
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            propertyValue: unknown
         ): void {
             this.mapEvents.trigger(
                 OSFramework.Maps.Event.OSMap.MapEventType.OnError,
@@ -244,14 +244,14 @@ namespace Provider.Maps.Google.OSMap {
         }
 
         // ChangeProperty method can't be used on a StaticMap
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             // If the StaticMap is already rendered then throw an error
             if (this.isReady) {
                 this.mapEvents.trigger(
                     OSFramework.Maps.Event.OSMap.MapEventType.OnError,
                     this,
-                    OSFramework.Maps.Enum.ErrorCodes.CFG_CantChangeParamsStaticMap
+                    OSFramework.Maps.Enum.ErrorCodes
+                        .CFG_CantChangeParamsStaticMap
                 );
                 return;
             }
@@ -271,13 +271,13 @@ namespace Provider.Maps.Google.OSMap {
                     }
                     return super.changeProperty(propertyName, value);
                 case OSFramework.Maps.Enum.OS_Config_StaticMap.center:
-                    this._center = this._getCenter(value);
+                    this._center = this._getCenter(value as string);
                     return;
                 case OSFramework.Maps.Enum.OS_Config_StaticMap.zoom:
-                    this._zoom = this._getZoom(value);
+                    this._zoom = this._getZoom(value as number);
                     return;
                 case OSFramework.Maps.Enum.OS_Config_StaticMap.type:
-                    this._type = value;
+                    this._type = value as OSFramework.Maps.Enum.OSMap.Type;
                     return;
                 default:
                     this.mapEvents.trigger(
@@ -295,8 +295,8 @@ namespace Provider.Maps.Google.OSMap {
             shapeId: string,
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            propertyValue: unknown
         ): void {
             this.mapEvents.trigger(
                 OSFramework.Maps.Event.OSMap.MapEventType.OnError,

--- a/src/Providers/Maps/Google/OSMap/StaticMap.ts
+++ b/src/Providers/Maps/Google/OSMap/StaticMap.ts
@@ -244,7 +244,10 @@ namespace Provider.Maps.Google.OSMap {
         }
 
         // ChangeProperty method can't be used on a StaticMap
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             // If the StaticMap is already rendered then throw an error
             if (this.isReady) {
                 this.mapEvents.trigger(
@@ -269,15 +272,16 @@ namespace Provider.Maps.Google.OSMap {
                                 .CFG_APIKeyAlreadySetStaticMap
                         );
                     }
-                    return super.changeProperty(propertyName, value);
+                    return super.changeProperty(propertyName, propertyValue);
                 case OSFramework.Maps.Enum.OS_Config_StaticMap.center:
-                    this._center = this._getCenter(value as string);
+                    this._center = this._getCenter(propertyValue as string);
                     return;
                 case OSFramework.Maps.Enum.OS_Config_StaticMap.zoom:
-                    this._zoom = this._getZoom(value as number);
+                    this._zoom = this._getZoom(propertyValue as number);
                     return;
                 case OSFramework.Maps.Enum.OS_Config_StaticMap.type:
-                    this._type = value as OSFramework.Maps.Enum.OSMap.Type;
+                    this._type =
+                        propertyValue as OSFramework.Maps.Enum.OSMap.Type;
                     return;
                 default:
                     this.mapEvents.trigger(

--- a/src/Providers/Maps/Google/SearchPlaces/Factory.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/Factory.ts
@@ -3,12 +3,9 @@ namespace Provider.Maps.Google.SearchPlaces {
     export namespace SearchPlacesFactory {
         export function MakeSearchPlaces(
             searchPlacesId: string,
-            configs: OSFramework.Maps.Configuration.IConfiguration
+            configs: JSON
         ): OSFramework.Maps.SearchPlaces.ISearchPlaces {
-            return new SearchPlaces(
-                searchPlacesId,
-                configs as Configuration.SearchPlaces.SearchPlacesConfig
-            );
+            return new SearchPlaces(searchPlacesId, configs);
         }
     }
 }

--- a/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
@@ -257,8 +257,11 @@ namespace Provider.Maps.Google.SearchPlaces {
             );
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
-            super.changeProperty(propertyName, value);
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
+            super.changeProperty(propertyName, propertyValue);
             if (this.isReady) {
                 switch (
                     OSFramework.Maps.Enum.OS_Config_SearchPlaces[propertyName]
@@ -278,7 +281,7 @@ namespace Provider.Maps.Google.SearchPlaces {
                         .searchArea:
                         // eslint-disable-next-line no-case-declarations
                         const searchArea = this._buildSearchArea(
-                            value as string
+                            propertyValue as string
                         );
                         // If searchArea is undefined (should be a promise) -> don't apply the searchArea (bounds)
                         if (searchArea !== undefined) {
@@ -307,7 +310,7 @@ namespace Provider.Maps.Google.SearchPlaces {
                         return;
                     case OSFramework.Maps.Enum.OS_Config_SearchPlaces.countries:
                         // eslint-disable-next-line no-case-declarations
-                        const countries = JSON.parse(value as string);
+                        const countries = JSON.parse(propertyValue as string);
                         // If validation returns false -> do nothing
                         // Else set restrictions to component (apply countries)
                         return (
@@ -321,7 +324,7 @@ namespace Provider.Maps.Google.SearchPlaces {
                         return this.provider.setTypes([
                             // eslint-disable-next-line @typescript-eslint/no-unused-vars
                             Provider.Maps.Google.SearchPlaces.SearchTypes[
-                                value as string
+                                propertyValue as string
                             ]
                         ]);
                 }

--- a/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
@@ -10,11 +10,7 @@ namespace Provider.Maps.Google.SearchPlaces {
         private _addedEvents: Array<string>;
         private _scriptCallback: OSFramework.Maps.Callbacks.Generic;
 
-        constructor(
-            searchPlacesId: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
-        ) {
+        constructor(searchPlacesId: string, configs: JSON) {
             super(
                 searchPlacesId,
                 new Configuration.SearchPlaces.SearchPlacesConfig(configs)
@@ -88,26 +84,34 @@ namespace Provider.Maps.Google.SearchPlaces {
                 script.removeEventListener('load', this._scriptCallback);
             }
             if (typeof google === 'object' && typeof google.maps === 'object') {
-                const configs = this.getProviderConfig();
+                const local_configs =
+                    this.getProviderConfig() as Configuration.SearchPlaces.ISearchPlacesProviderConfig;
                 // If all searchArea bounds are empty, then we don't want to create a searchArea
                 // If not, create a searchArea with the bounds that were specified
                 // But if one of the bounds is empty, throw an error
                 if (
                     OSFramework.Maps.Helper.HasAllEmptyBounds(
-                        configs.bounds
+                        local_configs.bounds
                     ) === false
                 ) {
-                    const bounds = this._convertStringToBounds(configs.bounds);
+                    const bounds = this._convertStringToBounds(
+                        local_configs.bounds
+                    );
                     // If countries > 5 than throw an error
                     if (
                         this._validCountriesMaxLength(this.config.countries) &&
                         bounds !== undefined
                     ) {
                         bounds
-                            .then((coords) => {
-                                configs.bounds = coords;
-                                this._createProvider(configs);
-                            })
+                            .then(
+                                (
+                                    coords: OSFramework.Maps.OSStructures.OSMap.Bounds
+                                ) => {
+                                    local_configs.bounds =
+                                        coords as unknown as OSFramework.Maps.OSStructures.OSMap.BoundsString;
+                                    this._createProvider(local_configs);
+                                }
+                            )
                             .catch((error) => {
                                 this.searchPlacesEvents.trigger(
                                     OSFramework.Maps.Event.SearchPlaces
@@ -121,17 +125,16 @@ namespace Provider.Maps.Google.SearchPlaces {
                             });
                     }
                 } else {
-                    delete configs.bounds;
-                    this._createProvider(configs);
+                    delete local_configs.bounds;
+                    this._createProvider(local_configs);
                 }
             } else {
                 throw Error(`The google.maps lib has not been loaded.`);
             }
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         private _createProvider(
-            configs: google.maps.places.AutocompleteOptions
+            configs: Configuration.SearchPlaces.ISearchPlacesProviderConfig
         ): void {
             const input: HTMLInputElement =
                 OSFramework.Maps.Helper.GetElementByUniqueId(
@@ -144,11 +147,11 @@ namespace Provider.Maps.Google.SearchPlaces {
             // SearchPlaces(input, options)
             this._provider = new google.maps.places.Autocomplete(
                 input,
-                configs
+                configs as unknown
             );
             // Check if the provider has been created with a valid APIKey
             window[OSFramework.Maps.Helper.Constants.googleMapsAuthFailure] =
-                () =>
+                () => {
                     this.searchPlacesEvents.trigger(
                         OSFramework.Maps.Event.SearchPlaces
                             .SearchPlacesEventType.OnError,
@@ -156,6 +159,7 @@ namespace Provider.Maps.Google.SearchPlaces {
                         OSFramework.Maps.Enum.ErrorCodes
                             .LIB_InvalidApiKeySearchPlaces
                     );
+                };
 
             this.finishBuild();
             this._setSearchPlacesEvents();
@@ -253,8 +257,7 @@ namespace Provider.Maps.Google.SearchPlaces {
             );
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             super.changeProperty(propertyName, value);
             if (this.isReady) {
                 switch (
@@ -274,7 +277,9 @@ namespace Provider.Maps.Google.SearchPlaces {
                     case OSFramework.Maps.Enum.OS_Config_SearchPlaces
                         .searchArea:
                         // eslint-disable-next-line no-case-declarations
-                        const searchArea = this._buildSearchArea(value);
+                        const searchArea = this._buildSearchArea(
+                            value as string
+                        );
                         // If searchArea is undefined (should be a promise) -> don't apply the searchArea (bounds)
                         if (searchArea !== undefined) {
                             searchArea
@@ -302,7 +307,7 @@ namespace Provider.Maps.Google.SearchPlaces {
                         return;
                     case OSFramework.Maps.Enum.OS_Config_SearchPlaces.countries:
                         // eslint-disable-next-line no-case-declarations
-                        const countries = JSON.parse(value);
+                        const countries = JSON.parse(value as string);
                         // If validation returns false -> do nothing
                         // Else set restrictions to component (apply countries)
                         return (
@@ -315,7 +320,9 @@ namespace Provider.Maps.Google.SearchPlaces {
                         .searchType:
                         return this.provider.setTypes([
                             // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                            Provider.Maps.Google.SearchPlaces.SearchTypes[value]
+                            Provider.Maps.Google.SearchPlaces.SearchTypes[
+                                value as string
+                            ]
                         ]);
                 }
             }

--- a/src/Providers/Maps/Google/Shape/AbstractPolyshape.ts
+++ b/src/Providers/Maps/Google/Shape/AbstractPolyshape.ts
@@ -109,15 +109,20 @@ namespace Provider.Maps.Google.Shape {
             this._buildProvider(shapePath);
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Shape.locations:
                         // eslint-disable-next-line no-case-declarations
-                        const shapePath = this._buildPath(value as string);
+                        const shapePath = this._buildPath(
+                            propertyValue as string
+                        );
                         // If path is undefined (should be a promise) -> don't create the shape
                         if (shapePath !== undefined) {
                             shapePath
@@ -136,7 +141,7 @@ namespace Provider.Maps.Google.Shape {
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillColor:
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillOpacity:
-                        return this.provider.set(propertyName, value);
+                        return this.provider.set(propertyName, propertyValue);
                 }
             }
         }

--- a/src/Providers/Maps/Google/Shape/AbstractPolyshape.ts
+++ b/src/Providers/Maps/Google/Shape/AbstractPolyshape.ts
@@ -83,8 +83,7 @@ namespace Provider.Maps.Google.Shape {
             return Constants.Shape.ProviderPolyshapeEvents;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public get providerObjectListener(): google.maps.MVCArray<any> {
+        public get providerObjectListener(): google.maps.MVCArray<unknown> {
             return this.provider.getPath();
         }
 
@@ -110,8 +109,7 @@ namespace Provider.Maps.Google.Shape {
             this._buildProvider(shapePath);
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
             super.changeProperty(propertyName, value);
@@ -119,7 +117,7 @@ namespace Provider.Maps.Google.Shape {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Shape.locations:
                         // eslint-disable-next-line no-case-declarations
-                        const shapePath = this._buildPath(value);
+                        const shapePath = this._buildPath(value as string);
                         // If path is undefined (should be a promise) -> don't create the shape
                         if (shapePath !== undefined) {
                             shapePath

--- a/src/Providers/Maps/Google/Shape/AbstractProviderShape.ts
+++ b/src/Providers/Maps/Google/Shape/AbstractProviderShape.ts
@@ -159,22 +159,28 @@ namespace Provider.Maps.Google.Shape {
             return Constants.Shape.Events;
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Shape.allowDrag:
-                        return this.provider.set('draggable', value);
+                        return this.provider.set('draggable', propertyValue);
                     case OSFramework.Maps.Enum.OS_Config_Shape.allowEdit:
-                        return this.provider.set('editable', value);
+                        return this.provider.set('editable', propertyValue);
                     case OSFramework.Maps.Enum.OS_Config_Shape.strokeOpacity:
-                        return this.provider.set('strokeOpacity', value);
+                        return this.provider.set(
+                            'strokeOpacity',
+                            propertyValue
+                        );
                     case OSFramework.Maps.Enum.OS_Config_Shape.strokeColor:
-                        return this.provider.set('strokeColor', value);
+                        return this.provider.set('strokeColor', propertyValue);
                     case OSFramework.Maps.Enum.OS_Config_Shape.strokeWeight:
-                        return this.provider.set('strokeWeight', value);
+                        return this.provider.set('strokeWeight', propertyValue);
                 }
             }
         }

--- a/src/Providers/Maps/Google/Shape/AbstractProviderShape.ts
+++ b/src/Providers/Maps/Google/Shape/AbstractProviderShape.ts
@@ -159,8 +159,7 @@ namespace Provider.Maps.Google.Shape {
             return Constants.Shape.Events;
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
             super.changeProperty(propertyName, value);
@@ -194,8 +193,9 @@ namespace Provider.Maps.Google.Shape {
 
         public abstract get providerEventsList(): Array<string>;
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public abstract get providerObjectListener(): any;
+        public abstract get providerObjectListener(): {
+            addListener: (eventName: string, cb: () => void) => void;
+        };
 
         public abstract get shapeTag(): string;
 

--- a/src/Providers/Maps/Google/Shape/Circle.ts
+++ b/src/Providers/Maps/Google/Shape/Circle.ts
@@ -125,15 +125,20 @@ namespace Provider.Maps.Google.Shape {
             super._buildProvider(shapeCenter);
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Shape.center:
                         // eslint-disable-next-line no-case-declarations
-                        const shapeCenter = this._buildCenter(value as string);
+                        const shapeCenter = this._buildCenter(
+                            propertyValue as string
+                        );
                         // If path is undefined (should be a promise) -> don't create the shape
                         if (shapeCenter !== undefined) {
                             shapeCenter
@@ -151,10 +156,10 @@ namespace Provider.Maps.Google.Shape {
                         }
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.radius:
-                        return this.provider.setRadius(value as number);
+                        return this.provider.setRadius(propertyValue as number);
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillColor:
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillOpacity:
-                        return this.provider.set(propertyName, value);
+                        return this.provider.set(propertyName, propertyValue);
                 }
             }
         }

--- a/src/Providers/Maps/Google/Shape/Circle.ts
+++ b/src/Providers/Maps/Google/Shape/Circle.ts
@@ -13,8 +13,7 @@ namespace Provider.Maps.Google.Shape {
             map: OSFramework.Maps.OSMap.IMap,
             shapeId: string,
             type: OSFramework.Maps.Enum.ShapeType,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: unknown
         ) {
             super(
                 map,
@@ -58,7 +57,7 @@ namespace Provider.Maps.Google.Shape {
             return new google.maps.Circle({
                 map: this.map.provider,
                 center,
-                ...this.getProviderConfig()
+                ...(this.getProviderConfig() as Configuration.Shape.IShapeProviderConfig)
             });
         }
 
@@ -126,8 +125,7 @@ namespace Provider.Maps.Google.Shape {
             super._buildProvider(shapeCenter);
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
             super.changeProperty(propertyName, value);
@@ -135,7 +133,7 @@ namespace Provider.Maps.Google.Shape {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Shape.center:
                         // eslint-disable-next-line no-case-declarations
-                        const shapeCenter = this._buildCenter(value);
+                        const shapeCenter = this._buildCenter(value as string);
                         // If path is undefined (should be a promise) -> don't create the shape
                         if (shapeCenter !== undefined) {
                             shapeCenter
@@ -153,7 +151,7 @@ namespace Provider.Maps.Google.Shape {
                         }
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.radius:
-                        return this.provider.setRadius(value);
+                        return this.provider.setRadius(value as number);
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillColor:
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillOpacity:
                         return this.provider.set(propertyName, value);

--- a/src/Providers/Maps/Google/Shape/Factory.ts
+++ b/src/Providers/Maps/Google/Shape/Factory.ts
@@ -5,7 +5,7 @@ namespace Provider.Maps.Google.Shape {
             map: OSFramework.Maps.OSMap.IMap,
             shapeId: string,
             type: OSFramework.Maps.Enum.ShapeType,
-            configs: JSON
+            configs: unknown
         ): OSFramework.Maps.Shape.IShape {
             switch (type) {
                 case OSFramework.Maps.Enum.ShapeType.Polygon:

--- a/src/Providers/Maps/Google/Shape/Polygon.ts
+++ b/src/Providers/Maps/Google/Shape/Polygon.ts
@@ -9,14 +9,11 @@ namespace Provider.Maps.Google.Shape {
         >
         implements OSFramework.Maps.Shape.IShapePolyshape
     {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-
         constructor(
             map: OSFramework.Maps.OSMap.IMap,
             shapeId: string,
             type: OSFramework.Maps.Enum.ShapeType,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: unknown
         ) {
             super(
                 map,
@@ -31,8 +28,8 @@ namespace Provider.Maps.Google.Shape {
         ): google.maps.Polygon {
             return new google.maps.Polygon({
                 map: this.map.provider,
-                path,
-                ...this.getProviderConfig()
+                paths: path,
+                ...(this.getProviderConfig() as Configuration.Shape.IShapeProviderConfig)
             });
         }
 

--- a/src/Providers/Maps/Google/Shape/Polyline.ts
+++ b/src/Providers/Maps/Google/Shape/Polyline.ts
@@ -13,8 +13,7 @@ namespace Provider.Maps.Google.Shape {
             map: OSFramework.Maps.OSMap.IMap,
             shapeId: string,
             type: OSFramework.Maps.Enum.ShapeType,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: unknown
         ) {
             super(
                 map,
@@ -29,8 +28,8 @@ namespace Provider.Maps.Google.Shape {
         ): google.maps.Polyline {
             return new google.maps.Polyline({
                 map: this.map.provider,
-                path,
-                ...this.getProviderConfig()
+                path: path,
+                ...(this.getProviderConfig() as Configuration.Shape.IShapeProviderConfig)
             });
         }
 

--- a/src/Providers/Maps/Google/Shape/Rectangle.ts
+++ b/src/Providers/Maps/Google/Shape/Rectangle.ts
@@ -13,8 +13,7 @@ namespace Provider.Maps.Google.Shape {
             map: OSFramework.Maps.OSMap.IMap,
             shapeId: string,
             type: OSFramework.Maps.Enum.ShapeType,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: unknown
         ) {
             super(
                 map,
@@ -100,8 +99,8 @@ namespace Provider.Maps.Google.Shape {
         ): google.maps.Rectangle {
             return new google.maps.Rectangle({
                 map: this.map.provider,
-                bounds,
-                ...this.getProviderConfig()
+                bounds: bounds,
+                ...(this.getProviderConfig() as Configuration.Shape.IShapeProviderConfig)
             });
         }
 
@@ -157,8 +156,7 @@ namespace Provider.Maps.Google.Shape {
             super._buildProvider(bounds);
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
             super.changeProperty(propertyName, value);
@@ -169,7 +167,7 @@ namespace Provider.Maps.Google.Shape {
                         return this.provider.set(propertyName, value);
                     case OSFramework.Maps.Enum.OS_Config_Shape.bounds:
                         // eslint-disable-next-line no-case-declarations
-                        const shapeBounds = this._buildBounds(value);
+                        const shapeBounds = this._buildBounds(value as string);
                         // If path is undefined (should be a promise) -> don't create the shape
                         if (shapeBounds !== undefined) {
                             shapeBounds

--- a/src/Providers/Maps/Google/Shape/Rectangle.ts
+++ b/src/Providers/Maps/Google/Shape/Rectangle.ts
@@ -156,18 +156,23 @@ namespace Provider.Maps.Google.Shape {
             super._buildProvider(bounds);
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillColor:
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillOpacity:
-                        return this.provider.set(propertyName, value);
+                        return this.provider.set(propertyName, propertyValue);
                     case OSFramework.Maps.Enum.OS_Config_Shape.bounds:
                         // eslint-disable-next-line no-case-declarations
-                        const shapeBounds = this._buildBounds(value as string);
+                        const shapeBounds = this._buildBounds(
+                            propertyValue as string
+                        );
                         // If path is undefined (should be a promise) -> don't create the shape
                         if (shapeBounds !== undefined) {
                             shapeBounds

--- a/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawBasicShapeConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawBasicShapeConfig.ts
@@ -8,7 +8,7 @@ namespace Provider.Maps.Leaflet.Configuration.DrawingTools {
         public strokeOpacity: number;
         public strokeWeight: number;
 
-        // No need for constructor, as it is not doing anything.
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
         // constructor(config: JSON) {
         //     super(config);
         // }

--- a/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawBasicShapeConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawBasicShapeConfig.ts
@@ -8,11 +8,7 @@ namespace Provider.Maps.Leaflet.Configuration.DrawingTools {
         public strokeOpacity: number;
         public strokeWeight: number;
 
-        constructor(
-            config:
-                | Configuration.DrawingTools.DrawFilledShapeConfig
-                | Configuration.DrawingTools.DrawBasicShapeConfig
-        ) {
+        constructor(config: JSON) {
             super(config);
         }
 

--- a/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawBasicShapeConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawBasicShapeConfig.ts
@@ -8,9 +8,10 @@ namespace Provider.Maps.Leaflet.Configuration.DrawingTools {
         public strokeOpacity: number;
         public strokeWeight: number;
 
-        constructor(config: JSON) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything.
+        // constructor(config: JSON) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawConfig.ts
@@ -9,12 +9,7 @@ namespace Provider.Maps.Leaflet.Configuration.DrawingTools {
         public allowDrag: boolean;
         public uniqueId: string;
 
-        constructor(
-            config:
-                | Configuration.DrawingTools.DrawFilledShapeConfig
-                | Configuration.DrawingTools.DrawBasicShapeConfig
-                | Configuration.DrawingTools.DrawMarkerConfig
-        ) {
+        constructor(config: JSON) {
             super(config);
         }
 

--- a/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawConfig.ts
@@ -9,7 +9,7 @@ namespace Provider.Maps.Leaflet.Configuration.DrawingTools {
         public allowDrag: boolean;
         public uniqueId: string;
 
-        // No need for constructor, as it is not doing anything.
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
         // constructor(config: JSON) {
         //     super(config);
         // }

--- a/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawConfig.ts
@@ -9,9 +9,10 @@ namespace Provider.Maps.Leaflet.Configuration.DrawingTools {
         public allowDrag: boolean;
         public uniqueId: string;
 
-        constructor(config: JSON) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything.
+        // constructor(config: JSON) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawFilledShapeConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawFilledShapeConfig.ts
@@ -6,7 +6,7 @@ namespace Provider.Maps.Leaflet.Configuration.DrawingTools {
         public fillColor: string;
         public fillOpacity: number;
 
-        constructor(config: Configuration.DrawingTools.DrawFilledShapeConfig) {
+        constructor(config: JSON) {
             super(config);
         }
 

--- a/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawFilledShapeConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawFilledShapeConfig.ts
@@ -6,9 +6,10 @@ namespace Provider.Maps.Leaflet.Configuration.DrawingTools {
         public fillColor: string;
         public fillOpacity: number;
 
-        constructor(config: JSON) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything.
+        // constructor(config: JSON) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawFilledShapeConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/DrawingTools/DrawFilledShapeConfig.ts
@@ -6,7 +6,7 @@ namespace Provider.Maps.Leaflet.Configuration.DrawingTools {
         public fillColor: string;
         public fillOpacity: number;
 
-        // No need for constructor, as it is not doing anything.
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
         // constructor(config: JSON) {
         //     super(config);
         // }

--- a/src/Providers/Maps/Leaflet/Configuration/Marker/LeafletMarkerConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/Marker/LeafletMarkerConfig.ts
@@ -6,25 +6,23 @@ namespace Provider.Maps.Leaflet.Configuration.Marker {
         extends OSFramework.Maps.Configuration.AbstractConfiguration
         implements OSFramework.Maps.Configuration.IConfigurationMarker
     {
-        public allowDrag: boolean;
-        public iconHeight: number;
-        public iconUrl: string;
-        public iconWidth: number;
-        public label: string;
+        public allowDrag?: boolean;
+        public iconHeight?: number;
+        public iconUrl?: string;
+        public iconWidth?: number;
+        public label?: string;
         public location: string;
-        public title: string;
+        public title?: string;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(
+            config: JSON | OSFramework.Maps.Configuration.IConfigurationMarker
+        ) {
             super(config);
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public getProviderConfig(): any {
-            const provider = {
+        public getProviderConfig(): L.MarkerOptions {
+            const provider: L.MarkerOptions = {
                 draggable: this.allowDrag,
-                iconUrl: this.iconUrl,
-                label: this.label,
                 title: this.title
             };
 

--- a/src/Providers/Maps/Leaflet/Configuration/Marker/LeafletMarkerConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/Marker/LeafletMarkerConfig.ts
@@ -14,11 +14,12 @@ namespace Provider.Maps.Leaflet.Configuration.Marker {
         public location: string;
         public title?: string;
 
-        constructor(
-            config: JSON | OSFramework.Maps.Configuration.IConfigurationMarker
-        ) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
+        // constructor(
+        //     config: JSON | OSFramework.Maps.Configuration.IConfigurationMarker
+        // ) {
+        //     super(config);
+        // }
 
         public getProviderConfig(): L.MarkerOptions {
             const provider: L.MarkerOptions = {

--- a/src/Providers/Maps/Leaflet/Configuration/OSMap/LeafletMapConfiguration.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/OSMap/LeafletMapConfiguration.ts
@@ -10,8 +10,7 @@ namespace Provider.Maps.Leaflet.Configuration.OSMap {
         public uniqueId: string;
         public zoom: OSFramework.Maps.Enum.OSMap.Zoom;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(config: JSON) {
             super(config);
         }
 

--- a/src/Providers/Maps/Leaflet/Configuration/OSMap/LeafletMapConfiguration.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/OSMap/LeafletMapConfiguration.ts
@@ -10,9 +10,10 @@ namespace Provider.Maps.Leaflet.Configuration.OSMap {
         public uniqueId: string;
         public zoom: OSFramework.Maps.Enum.OSMap.Zoom;
 
-        constructor(config: JSON) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything.
+        // constructor(config: JSON) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Leaflet/Configuration/OSMap/LeafletMapConfiguration.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/OSMap/LeafletMapConfiguration.ts
@@ -10,7 +10,7 @@ namespace Provider.Maps.Leaflet.Configuration.OSMap {
         public uniqueId: string;
         public zoom: OSFramework.Maps.Enum.OSMap.Zoom;
 
-        // No need for constructor, as it is not doing anything.
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
         // constructor(config: JSON) {
         //     super(config);
         // }

--- a/src/Providers/Maps/Leaflet/Configuration/Shape/BasicShapeConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/Shape/BasicShapeConfig.ts
@@ -13,11 +13,12 @@ namespace Provider.Maps.Leaflet.Configuration.Shape {
         public strokeOpacity: number;
         public strokeWeight: number;
 
-        constructor(
-            config: OSFramework.Maps.Configuration.IConfigurationShape
-        ) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
+        // constructor(
+        //     config: OSFramework.Maps.Configuration.IConfigurationShape
+        // ) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Leaflet/Configuration/Shape/BasicShapeConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/Shape/BasicShapeConfig.ts
@@ -13,8 +13,9 @@ namespace Provider.Maps.Leaflet.Configuration.Shape {
         public strokeOpacity: number;
         public strokeWeight: number;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(
+            config: OSFramework.Maps.Configuration.IConfigurationShape
+        ) {
             super(config);
         }
 

--- a/src/Providers/Maps/Leaflet/Configuration/Shape/CircleShapeConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/Shape/CircleShapeConfig.ts
@@ -6,11 +6,12 @@ namespace Provider.Maps.Leaflet.Configuration.Shape {
         public center: string;
         public radius: number;
 
-        constructor(
-            config: OSFramework.Maps.Configuration.IConfigurationShape
-        ) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
+        // constructor(
+        //     config: OSFramework.Maps.Configuration.IConfigurationShape
+        // ) {
+        //     super(config);
+        // }
 
         public getProviderConfig(): L.CircleOptions {
             const provider = super.getProviderConfig();

--- a/src/Providers/Maps/Leaflet/Configuration/Shape/CircleShapeConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/Shape/CircleShapeConfig.ts
@@ -6,13 +6,13 @@ namespace Provider.Maps.Leaflet.Configuration.Shape {
         public center: string;
         public radius: number;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(
+            config: OSFramework.Maps.Configuration.IConfigurationShape
+        ) {
             super(config);
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public getProviderConfig(): any {
+        public getProviderConfig(): L.CircleOptions {
             const provider = super.getProviderConfig();
             provider.radius = this.radius;
 
@@ -20,7 +20,7 @@ namespace Provider.Maps.Leaflet.Configuration.Shape {
             // We can remove it from the provider configs
             delete provider.locations;
 
-            return provider;
+            return provider as L.CircleOptions;
         }
     }
 }

--- a/src/Providers/Maps/Leaflet/Configuration/Shape/FilledShapeConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/Shape/FilledShapeConfig.ts
@@ -6,8 +6,9 @@ namespace Provider.Maps.Leaflet.Configuration.Shape {
         public fillColor: string;
         public fillOpacity: number;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(
+            config: OSFramework.Maps.Configuration.IConfigurationShape
+        ) {
             super(config);
         }
 

--- a/src/Providers/Maps/Leaflet/Configuration/Shape/FilledShapeConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/Shape/FilledShapeConfig.ts
@@ -6,11 +6,12 @@ namespace Provider.Maps.Leaflet.Configuration.Shape {
         public fillColor: string;
         public fillOpacity: number;
 
-        constructor(
-            config: OSFramework.Maps.Configuration.IConfigurationShape
-        ) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
+        // constructor(
+        //     config: OSFramework.Maps.Configuration.IConfigurationShape
+        // ) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Leaflet/Configuration/Shape/RectangleShapeConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/Shape/RectangleShapeConfig.ts
@@ -5,8 +5,9 @@ namespace Provider.Maps.Leaflet.Configuration.Shape {
     export class RectangleShapeConfig extends FilledShapeConfig {
         public bounds: string;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(config: any) {
+        constructor(
+            config: OSFramework.Maps.Configuration.IConfigurationShape
+        ) {
             super(config);
         }
 

--- a/src/Providers/Maps/Leaflet/Configuration/Shape/RectangleShapeConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/Shape/RectangleShapeConfig.ts
@@ -5,11 +5,12 @@ namespace Provider.Maps.Leaflet.Configuration.Shape {
     export class RectangleShapeConfig extends FilledShapeConfig {
         public bounds: string;
 
-        constructor(
-            config: OSFramework.Maps.Configuration.IConfigurationShape
-        ) {
-            super(config);
-        }
+        // No need for constructor, as it is not doing anything. Left the constructor, to facilitade future usage.
+        // constructor(
+        //     config: OSFramework.Maps.Configuration.IConfigurationShape
+        // ) {
+        //     super(config);
+        // }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         public getProviderConfig(): any {

--- a/src/Providers/Maps/Leaflet/DrawingTools/AbstractDrawShape.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/AbstractDrawShape.ts
@@ -97,27 +97,40 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             this.options = this.getProviderConfig();
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.drawingTools.isReady) {
                 switch (propValue) {
                     // If the following configurations are not included on the configs of the tool, the AbstractTool will make sure to throw an error
                     case OSFramework.Maps.Enum.OS_Config_Shape.strokeOpacity:
-                        this.options = { shapeOptions: { opacity: value } };
+                        this.options = {
+                            shapeOptions: { opacity: propertyValue }
+                        };
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.strokeColor:
-                        this.options = { shapeOptions: { color: value } };
+                        this.options = {
+                            shapeOptions: { color: propertyValue }
+                        };
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.strokeWeight:
-                        this.options = { shapeOptions: { weight: value } };
+                        this.options = {
+                            shapeOptions: { weight: propertyValue }
+                        };
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillOpacity:
-                        this.options = { shapeOptions: { fillOpacity: value } };
+                        this.options = {
+                            shapeOptions: { fillOpacity: propertyValue }
+                        };
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillColor:
-                        this.options = { shapeOptions: { fillColor: value } };
+                        this.options = {
+                            shapeOptions: { fillColor: propertyValue }
+                        };
                         return;
                 }
             }

--- a/src/Providers/Maps/Leaflet/DrawingTools/AbstractDrawShape.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/AbstractDrawShape.ts
@@ -10,8 +10,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             drawingToolsId: string,
             type: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: W
         ) {
             super(map, drawingTools, drawingToolsId, type, configs);
         }
@@ -28,13 +27,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
                     eventName: string,
                     shapeCoordinates: OSFramework.Maps.OSStructures.OSMap.OSShapeCoordinates
                 ) => {
-                    this.drawingTools.drawingToolsEvents.trigger(
-                        // EventType
-                        OSFramework.Maps.Event.DrawingTools
-                            .DrawingToolsEventType.ProviderEvent,
-                        // EventName
-                        this.completedToolEventName,
-                        // The extra parameters, uniqueId and isNewElement set to false indicating that the element is not new
+                    const dtparams: OSFramework.Maps.DrawingTools.IDrawingToolsEventParams =
                         {
                             uniqueId: _shape.uniqueId,
                             isNewElement: false,
@@ -42,7 +35,16 @@ namespace Provider.Maps.Leaflet.DrawingTools {
                             coordinates: JSON.stringify(
                                 shapeCoordinates.coordinates
                             )
-                        }
+                        };
+
+                    this.drawingTools.drawingToolsEvents.trigger(
+                        // EventType
+                        OSFramework.Maps.Event.DrawingTools
+                            .DrawingToolsEventType.ProviderEvent,
+                        // EventName
+                        this.completedToolEventName,
+                        // The extra parameters, uniqueId and isNewElement set to false indicating that the element is not new
+                        dtparams
                     );
                 }
             );
@@ -52,8 +54,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
         protected createShapeElement(
             uniqueId: string,
             type: OSFramework.Maps.Enum.ShapeType,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: OSFramework.Maps.Configuration.IConfigurationShape
         ): OSFramework.Maps.Shape.IShape {
             const _shape = Shape.ShapeFactory.MakeShape(
                 this.map,
@@ -96,8 +97,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             this.options = this.getProviderConfig();
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
             super.changeProperty(propertyName, value);

--- a/src/Providers/Maps/Leaflet/DrawingTools/AbstractProviderTool.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/AbstractProviderTool.ts
@@ -71,6 +71,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
 
         // Adds the completedElement (completemarker, completepolyline, etc.) event listeners to the correspondent element.
         // The new handlers will create the shape/markers elements and remove the overlay created by the drawing tool on the map
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         public addCompletedEvent(event: any): void {
             this._addCompletedEventHandler(event);
         }

--- a/src/Providers/Maps/Leaflet/DrawingTools/AbstractProviderTool.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/AbstractProviderTool.ts
@@ -14,8 +14,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             drawingToolsId: string,
             type: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: T
         ) {
             super(map, drawingTools, drawingToolsId, type, configs);
             this.internalOptions = {};
@@ -88,12 +87,10 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             super.dispose();
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        public abstract get options(): any;
+        public abstract get options(): unknown;
         protected abstract get completedToolEventName(): string;
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-        protected abstract set options(options: any);
+        protected abstract set options(options: unknown);
 
         /**
          * Creates a new element based on the new element provider that results from the marker or shape complete events.
@@ -104,10 +101,8 @@ namespace Provider.Maps.Leaflet.DrawingTools {
          */
         protected abstract createElement(
             uniqueId: string,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-            element: any,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-            configs: any
+            element: unknown,
+            configs: OSFramework.Maps.Configuration.IConfiguration
         ): void;
 
         protected abstract getCoordinates(): string;

--- a/src/Providers/Maps/Leaflet/DrawingTools/DrawCircle.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/DrawCircle.ts
@@ -8,7 +8,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             drawingToolsId: string,
             type: string,
-            configs: Configuration.DrawingTools.DrawFilledShapeConfig
+            configs: JSON
         ) {
             super(
                 map,
@@ -22,7 +22,6 @@ namespace Provider.Maps.Leaflet.DrawingTools {
         private _createConfigsElement(
             shape: L.Circle,
             configs: Configuration.Shape.CircleShapeConfig
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ): Configuration.Shape.CircleShapeConfig {
             const providerCenter = shape.getLatLng();
             const center = `${providerCenter.lat},${providerCenter.lng}`;

--- a/src/Providers/Maps/Leaflet/DrawingTools/DrawMarker.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/DrawMarker.ts
@@ -164,15 +164,18 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             };
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Marker[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.drawingTools.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Marker.iconUrl:
                         this.options = {
-                            icon: this._createIcon(value as string)
+                            icon: this._createIcon(propertyValue as string)
                         };
                         return;
                 }

--- a/src/Providers/Maps/Leaflet/DrawingTools/DrawMarker.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/DrawMarker.ts
@@ -10,7 +10,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             drawingToolsId: string,
             type: string,
-            configs: Configuration.DrawingTools.DrawMarkerConfig
+            configs: JSON
         ) {
             super(
                 map,
@@ -109,15 +109,18 @@ namespace Provider.Maps.Leaflet.DrawingTools {
         protected createElement(
             uniqueId: string,
             marker: L.Marker,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: OSFramework.Maps.Configuration.IConfigurationTool
         ): OSFramework.Maps.Marker.IMarker {
             const location = `${marker.getLatLng().lat},${
                 marker.getLatLng().lng
             }`;
 
             // Join both the configs that were provided for the new marker element and the location that was provided by the DrawingTools markercomplete event
-            const finalConfigs = { ...configs, location };
+            const finalConfigs: OSFramework.Maps.Configuration.IConfigurationMarker =
+                {
+                    ...configs,
+                    location
+                };
 
             const _marker = Marker.MarkerFactory.MakeMarker(
                 this.map,
@@ -161,15 +164,16 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             };
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Marker[propertyName];
             super.changeProperty(propertyName, value);
             if (this.drawingTools.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Marker.iconUrl:
-                        this.options = { icon: this._createIcon(value) };
+                        this.options = {
+                            icon: this._createIcon(value as string)
+                        };
                         return;
                 }
             }

--- a/src/Providers/Maps/Leaflet/DrawingTools/DrawPolygon.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/DrawPolygon.ts
@@ -6,7 +6,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             drawingToolsId: string,
             type: string,
-            configs: Configuration.DrawingTools.DrawFilledShapeConfig
+            configs: JSON
         ) {
             super(
                 map,

--- a/src/Providers/Maps/Leaflet/DrawingTools/DrawPolyline.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/DrawPolyline.ts
@@ -6,7 +6,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             drawingToolsId: string,
             type: string,
-            configs: Configuration.DrawingTools.DrawBasicShapeConfig
+            configs: JSON
         ) {
             super(
                 map,

--- a/src/Providers/Maps/Leaflet/DrawingTools/DrawRectangle.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/DrawRectangle.ts
@@ -8,7 +8,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             drawingToolsId: string,
             type: string,
-            configs: Configuration.DrawingTools.DrawFilledShapeConfig
+            configs: JSON
         ) {
             super(
                 map,
@@ -51,7 +51,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
         }
 
         //TODO: create structure for rectangle options
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         protected set options(options: any) {
             const allOptions = { ...this.options, ...options };
             const shapeOptions = {

--- a/src/Providers/Maps/Leaflet/DrawingTools/DrawingTools.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/DrawingTools.ts
@@ -5,17 +5,12 @@ namespace Provider.Maps.Leaflet.DrawingTools {
     class ToolsList {
         //TODO - Create/optimize types for all the tools by using a global.d.ts or ussi
         //     - In that moment each tool should be boolean | NEW_TYPE because the empty state is false.
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public circle: any;
+        public circle: unknown;
         public circlemarker: boolean;
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public marker: any;
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public polygon: any;
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public polyline: any;
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public rectangle: any;
+        public marker: unknown;
+        public polygon: unknown;
+        public polyline: unknown;
+        public rectangle: unknown;
 
         constructor() {
             this.circlemarker = false; // this tool isn't provided by our experience
@@ -36,12 +31,10 @@ namespace Provider.Maps.Leaflet.DrawingTools {
         OSFramework.Maps.Configuration.IConfigurationDrawingTools
     > {
         // FeatureGroup <any>: as required by Leaflet
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        private _toolsGroup: L.FeatureGroup<any>;
+        private _toolsGroup: L.FeatureGroup<unknown>;
         //TODO - At the moment the type is not well defined and it doesn't included setDrawingOptions for example,
         //     - When this is done the overwrite of the _provider is not needed anymore.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        protected _provider: any;
+        //protected _provider: any;
 
         constructor(
             map: OSFramework.Maps.OSMap.IMap,
@@ -116,6 +109,8 @@ namespace Provider.Maps.Leaflet.DrawingTools {
                 ...drawingOptions,
                 draw: this._getTools()
             };
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            //@ts-ignore
             this._provider.setDrawingOptions(finalDrawingOptions.draw);
         }
 
@@ -143,13 +138,16 @@ namespace Provider.Maps.Leaflet.DrawingTools {
         // We don't have the types for the drawingTools features
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         protected get controlOptions(): any {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            //@ts-ignore
             return this._provider.get('drawingControlOptions');
         }
 
         // We don't have the types for the drawingTools features
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        protected set controlOptions(options: any) {
+        protected set controlOptions(options: unknown[]) {
             const allOptions = { ...this.controlOptions, ...options };
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            //@ts-ignore
             this._provider.setOptions({
                 drawingControlOptions: allOptions
             });
@@ -200,8 +198,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             this.finishBuild();
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_DrawingTools[propertyName];
             super.changeProperty(propertyName, value);
@@ -209,8 +206,9 @@ namespace Provider.Maps.Leaflet.DrawingTools {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_DrawingTools.position:
                         // eslint-disable-next-line no-case-declarations
-                        const positionValue =
-                            this._getDrawingToolsPosition(value);
+                        const positionValue = this._getDrawingToolsPosition(
+                            value as string
+                        );
                         positionValue &&
                             this.provider.setPosition(positionValue);
                         return;

--- a/src/Providers/Maps/Leaflet/DrawingTools/DrawingTools.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/DrawingTools.ts
@@ -198,16 +198,19 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             this.finishBuild();
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_DrawingTools[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_DrawingTools.position:
                         // eslint-disable-next-line no-case-declarations
                         const positionValue = this._getDrawingToolsPosition(
-                            value as string
+                            propertyValue as string
                         );
                         positionValue &&
                             this.provider.setPosition(positionValue);

--- a/src/Providers/Maps/Leaflet/DrawingTools/Factory.ts
+++ b/src/Providers/Maps/Leaflet/DrawingTools/Factory.ts
@@ -4,13 +4,11 @@ namespace Provider.Maps.Leaflet.DrawingTools {
         export function MakeDrawingTools(
             map: OSFramework.Maps.OSMap.IMap,
             drawingToolsId: string,
-            configs: OSFramework.Maps.Configuration.IConfiguration
+            configs: JSON
         ): OSFramework.Maps.DrawingTools.IDrawingTools {
-            return new DrawingTools(
-                map,
-                drawingToolsId,
-                configs as Configuration.DrawingTools.DrawingToolsConfig
-            );
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            //@ts-ignore
+            return new DrawingTools(map, drawingToolsId, configs);
         }
 
         export function MakeTool(
@@ -18,7 +16,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
             drawingTools: OSFramework.Maps.DrawingTools.IDrawingTools,
             toolId: string,
             type: OSFramework.Maps.Enum.DrawingToolsTypes,
-            configs: OSFramework.Maps.Configuration.IConfiguration
+            configs: JSON
         ): OSFramework.Maps.DrawingTools.ITool {
             switch (type) {
                 case OSFramework.Maps.Enum.DrawingToolsTypes.Marker:
@@ -27,7 +25,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
                         drawingTools,
                         toolId,
                         type,
-                        configs as Configuration.DrawingTools.DrawMarkerConfig
+                        configs
                     );
                 case OSFramework.Maps.Enum.DrawingToolsTypes.Polyline:
                     return new DrawPolyline(
@@ -35,7 +33,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
                         drawingTools,
                         toolId,
                         type,
-                        configs as Configuration.DrawingTools.DrawBasicShapeConfig
+                        configs
                     );
                 case OSFramework.Maps.Enum.DrawingToolsTypes.Polygon:
                     return new DrawPolygon(
@@ -43,7 +41,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
                         drawingTools,
                         toolId,
                         type,
-                        configs as Configuration.DrawingTools.DrawFilledShapeConfig
+                        configs
                     );
                 case OSFramework.Maps.Enum.DrawingToolsTypes.Circle:
                     return new DrawCircle(
@@ -51,7 +49,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
                         drawingTools,
                         toolId,
                         type,
-                        configs as Configuration.DrawingTools.DrawFilledShapeConfig
+                        configs
                     );
                 case OSFramework.Maps.Enum.DrawingToolsTypes.Rectangle:
                     return new DrawRectangle(
@@ -59,7 +57,7 @@ namespace Provider.Maps.Leaflet.DrawingTools {
                         drawingTools,
                         toolId,
                         type,
-                        configs as Configuration.DrawingTools.DrawFilledShapeConfig
+                        configs
                     );
                 default:
                     throw new Error(

--- a/src/Providers/Maps/Leaflet/Features/Directions.ts
+++ b/src/Providers/Maps/Leaflet/Features/Directions.ts
@@ -27,8 +27,7 @@ namespace Provider.Maps.Leaflet.Feature {
         /** TooltipOptions for the Text that will appear over the Waypoint Icon*/
         private _defaultTooltip: L.TooltipOptions;
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        private _directionsRenderer: any;
+        private _directionsRenderer: ILeafletRoutingControl;
 
         private _isEnabled: boolean;
         private _map: OSMap.IMapLeaflet;
@@ -126,8 +125,11 @@ namespace Provider.Maps.Leaflet.Feature {
         private _routesFoundHandler(
             resolve?: OSFramework.Maps.Callbacks.Generic,
             resolveType?: ResolveType,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            e?: any
+            e?: {
+                routes: [
+                    { summary: { totalDistance: number; totalTime: number } }
+                ];
+            }
         ) {
             let bind: OSFramework.Maps.Callbacks.Generic;
             // This method was invoked by the setRoute and because there might exist concurrency between the setRoute and the getDistance or getDirections methods
@@ -170,7 +172,7 @@ namespace Provider.Maps.Leaflet.Feature {
             // If the Map has no directionsRenderer, return false.
             if (this._hasDirectionsRenderer() === false) return false;
 
-            const exclude = [];
+            const exclude: string[] = [];
             dirExclude.avoidTolls && exclude.push('toll');
             dirExclude.avoidHighways && exclude.push('motorway');
             dirExclude.avoidFerries && exclude.push('ferry');
@@ -412,7 +414,9 @@ namespace Provider.Maps.Leaflet.Feature {
                     this._directionsRenderer.addTo(this._map.provider);
             } else {
                 this._directionsRenderer &&
-                    this._map.provider.removeControl(this._directionsRenderer);
+                    this._map.provider.removeControl(
+                        this._directionsRenderer as unknown as L.Control
+                    );
             }
             this._isEnabled = value;
         }

--- a/src/Providers/Maps/Leaflet/Features/FeatureBuilder.ts
+++ b/src/Providers/Maps/Leaflet/Features/FeatureBuilder.ts
@@ -18,7 +18,7 @@ namespace Provider.Maps.Leaflet.Feature {
             this._features = new OSFramework.Maps.Feature.ExposedFeatures();
         }
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-explicit-any
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         private _instanceOfIDisposable(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             object: any
@@ -27,10 +27,9 @@ namespace Provider.Maps.Leaflet.Feature {
         }
 
         protected _makeItem<T extends OSFramework.Maps.Interface.IBuilder>(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            c: new (...args: any) => T,
+            c: new (...args: unknown[]) => T,
             // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-            ...args
+            ...args: unknown[]
         ): T {
             const o = new c(this._map, ...args);
             this._featureList.push(o);

--- a/src/Providers/Maps/Leaflet/Features/ILeafletRoutingControl.ts
+++ b/src/Providers/Maps/Leaflet/Features/ILeafletRoutingControl.ts
@@ -1,0 +1,24 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace Provider.Maps.Leaflet.Feature {
+    export interface ILeafletRoutingControl {
+        addTo(map: L.Map): void;
+        getContainer?(): HTMLElement;
+        getPlan(): unknown;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        getRouter(): any;
+        getWaypoints(): unknown[];
+        off?(type: string, fn: (event: unknown) => void);
+        on(
+            type: string,
+            fn: (event: unknown) => void,
+            context?: unknown
+        ): unknown;
+        route(param: unknown): void;
+        setWaypoints(waypoints: unknown[]): unknown;
+        spliceWaypoints(
+            index: number,
+            waypointsToRemove: number,
+            ...wayPoints: unknown[]
+        ): unknown[];
+    }
+}

--- a/src/Providers/Maps/Leaflet/Marker/Factory.ts
+++ b/src/Providers/Maps/Leaflet/Marker/Factory.ts
@@ -5,7 +5,7 @@ namespace Provider.Maps.Leaflet.Marker {
             map: OSFramework.Maps.OSMap.IMap,
             markerId: string,
             type: OSFramework.Maps.Enum.MarkerType,
-            configs: Configuration.Marker.LeafletMarkerConfig
+            configs: JSON | OSFramework.Maps.Configuration.IConfigurationMarker
         ): OSFramework.Maps.Marker.IMarker {
             switch (type) {
                 case OSFramework.Maps.Enum.MarkerType.Marker:

--- a/src/Providers/Maps/Leaflet/Marker/Marker.ts
+++ b/src/Providers/Maps/Leaflet/Marker/Marker.ts
@@ -291,14 +291,19 @@ namespace Provider.Maps.Leaflet.Marker {
             }
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const property =
                 OSFramework.Maps.Enum.OS_Config_Marker[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.isReady) {
                 switch (property) {
                     case OSFramework.Maps.Enum.OS_Config_Marker.location:
-                        Helper.Conversions.ValidateCoordinates(value as string)
+                        Helper.Conversions.ValidateCoordinates(
+                            propertyValue as string
+                        )
                             .then((response) => {
                                 this._provider.setLatLng({
                                     lat: response.lat,
@@ -317,7 +322,7 @@ namespace Provider.Maps.Leaflet.Marker {
                             });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.allowDrag:
-                        value
+                        propertyValue
                             ? this._provider.dragging.enable()
                             : this._provider.dragging.disable();
                         return;
@@ -325,16 +330,17 @@ namespace Provider.Maps.Leaflet.Marker {
                         this._setIconSize();
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.iconUrl:
-                        this._setIcon(value as string);
+                        this._setIcon(propertyValue as string);
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.iconWidth:
                         this._setIconSize();
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.label:
-                        this._setLabelContent(value as string);
+                        this._setLabelContent(propertyValue as string);
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.title:
-                        this._provider.getElement().title = value as string;
+                        this._provider.getElement().title =
+                            propertyValue as string;
                         return;
                 }
             }

--- a/src/Providers/Maps/Leaflet/Marker/Marker.ts
+++ b/src/Providers/Maps/Leaflet/Marker/Marker.ts
@@ -17,7 +17,7 @@ namespace Provider.Maps.Leaflet.Marker {
             map: OSFramework.Maps.OSMap.IMap,
             markerId: string,
             type: OSFramework.Maps.Enum.MarkerType,
-            configs: Configuration.Marker.LeafletMarkerConfig
+            configs: JSON | OSFramework.Maps.Configuration.IConfigurationMarker
         ) {
             super(
                 map,
@@ -39,8 +39,8 @@ namespace Provider.Maps.Leaflet.Marker {
         }
 
         private async _getMeta(
-            url
-        ): Promise<{ width: number; height: number }> {
+            url: string
+        ): Promise<{ height: number; width: number }> {
             return new Promise((resolve, reject) => {
                 const img = new Image();
                 img.onload = () =>
@@ -260,14 +260,15 @@ namespace Provider.Maps.Leaflet.Marker {
             // Then, set Marker events
             // Finally, refresh the Map
             const markerLocation = this._buildMarkerLocation();
-            const configs = this.getProviderConfig();
+            const provider_configs =
+                this.getProviderConfig() as L.MarkerOptions;
             // If markerOptions is undefined (should be a promise) -> don't create the marker
             if (markerLocation !== undefined) {
                 markerLocation
                     .then((location: L.LatLng) => {
-                        this._provider = L.marker(location, configs);
-                        this._setIcon(configs.iconUrl);
-                        this._setLabelContent(configs.label);
+                        this._provider = L.marker(location, provider_configs);
+                        this._setIcon(this.config.iconUrl);
+                        this._setLabelContent(this.config.label);
 
                         this._provider.addTo(this.map.provider);
                         // We can only set the events on the provider after its creation
@@ -290,15 +291,14 @@ namespace Provider.Maps.Leaflet.Marker {
             }
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const property =
                 OSFramework.Maps.Enum.OS_Config_Marker[propertyName];
             super.changeProperty(propertyName, value);
             if (this.isReady) {
                 switch (property) {
                     case OSFramework.Maps.Enum.OS_Config_Marker.location:
-                        Helper.Conversions.ValidateCoordinates(value)
+                        Helper.Conversions.ValidateCoordinates(value as string)
                             .then((response) => {
                                 this._provider.setLatLng({
                                     lat: response.lat,
@@ -325,16 +325,16 @@ namespace Provider.Maps.Leaflet.Marker {
                         this._setIconSize();
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.iconUrl:
-                        this._setIcon(value);
+                        this._setIcon(value as string);
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.iconWidth:
                         this._setIconSize();
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.label:
-                        this._setLabelContent(value);
+                        this._setLabelContent(value as string);
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Marker.title:
-                        this._provider.getElement().title = value;
+                        this._provider.getElement().title = value as string;
                         return;
                 }
             }

--- a/src/Providers/Maps/Leaflet/OSMap/Factory.ts
+++ b/src/Providers/Maps/Leaflet/OSMap/Factory.ts
@@ -4,14 +4,11 @@ namespace Provider.Maps.Leaflet.OSMap {
         export function MakeMap(
             type: OSFramework.Maps.Enum.MapType,
             mapdId: string,
-            configs: OSFramework.Maps.Configuration.IConfiguration
+            configs: JSON
         ): OSFramework.Maps.OSMap.IMap {
             switch (type) {
                 case OSFramework.Maps.Enum.MapType.Map:
-                    return new Map(
-                        mapdId,
-                        configs as Configuration.OSMap.LeafletMapConfig
-                    );
+                    return new Map(mapdId, configs);
                 //Right now there is no StaticMap for the Leaflet provider
                 case OSFramework.Maps.Enum.MapType.StaticMap:
                 default:

--- a/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
@@ -13,8 +13,7 @@ namespace Provider.Maps.Leaflet.OSMap {
         private _fBuilder: Feature.FeatureBuilder;
         private _openStreetMapLayer: L.TileLayer;
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        constructor(mapId: string, configs: any) {
+        constructor(mapId: string, configs: JSON) {
             super(
                 mapId,
                 OSFramework.Maps.Enum.ProviderType.Leaflet,
@@ -46,7 +45,6 @@ namespace Provider.Maps.Leaflet.OSMap {
             this.shapes.forEach((shape) => shape.build());
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         private _getProviderConfig(): L.MapOptions {
             // Make sure the center has a default value before the conversion of the location to coordinates
             this.config.center =
@@ -202,8 +200,7 @@ namespace Provider.Maps.Leaflet.OSMap {
         public changeDrawingToolsProperty(
             drawingToolsId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void {
             // There is only one (max) drawingTools element per map
             const drawingTools = this.drawingTools;
@@ -223,8 +220,7 @@ namespace Provider.Maps.Leaflet.OSMap {
         public changeFileLayerProperty(
             fileLayerId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void {
             // There is only one (max) drawingTools element per map
             const fileLayer = this.getFileLayer(fileLayerId);
@@ -241,8 +237,7 @@ namespace Provider.Maps.Leaflet.OSMap {
         public changeHeatmapLayerProperty(
             heatmapLayerId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void {
             const heatmapLayer = this.getHeatmapLayer(heatmapLayerId);
 
@@ -258,8 +253,7 @@ namespace Provider.Maps.Leaflet.OSMap {
         public changeMarkerProperty(
             markerId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void {
             const marker = this.getMarker(markerId);
 
@@ -272,20 +266,23 @@ namespace Provider.Maps.Leaflet.OSMap {
             }
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const propValue = OSFramework.Maps.Enum.OS_Config_Map[propertyName];
             super.changeProperty(propertyName, value);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Map.center:
-                        return this.features.center.updateCenter(value);
+                        return this.features.center.updateCenter(
+                            value as string
+                        );
                     case OSFramework.Maps.Enum.OS_Config_Map.offset:
                         return this.features.offset.setOffset(
-                            JSON.parse(value)
+                            JSON.parse(value as string)
                         );
                     case OSFramework.Maps.Enum.OS_Config_Map.zoom:
-                        return this.features.zoom.setLevel(value);
+                        return this.features.zoom.setLevel(
+                            value as OSFramework.Maps.Enum.OSMap.Zoom
+                        );
                 }
             }
         }
@@ -293,8 +290,7 @@ namespace Provider.Maps.Leaflet.OSMap {
         public changeShapeProperty(
             shapeId: string,
             propertyName: string,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            propertyValue: any
+            propertyValue: unknown
         ): void {
             const shape = this.getShape(shapeId);
 

--- a/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
@@ -266,22 +266,25 @@ namespace Provider.Maps.Leaflet.OSMap {
             }
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const propValue = OSFramework.Maps.Enum.OS_Config_Map[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Map.center:
                         return this.features.center.updateCenter(
-                            value as string
+                            propertyValue as string
                         );
                     case OSFramework.Maps.Enum.OS_Config_Map.offset:
                         return this.features.offset.setOffset(
-                            JSON.parse(value as string)
+                            JSON.parse(propertyValue as string)
                         );
                     case OSFramework.Maps.Enum.OS_Config_Map.zoom:
                         return this.features.zoom.setLevel(
-                            value as OSFramework.Maps.Enum.OSMap.Zoom
+                            propertyValue as OSFramework.Maps.Enum.OSMap.Zoom
                         );
                 }
             }

--- a/src/Providers/Maps/Leaflet/Shape/AbstractPolyshape.ts
+++ b/src/Providers/Maps/Leaflet/Shape/AbstractPolyshape.ts
@@ -106,15 +106,20 @@ namespace Provider.Maps.Leaflet.Shape {
             this.buildProvider(shapePath);
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Shape.locations:
                         // eslint-disable-next-line no-case-declarations
-                        const shapePath = this._buildPath(value as string);
+                        const shapePath = this._buildPath(
+                            propertyValue as string
+                        );
                         // If path is undefined (should be a promise) -> don't create the shape
                         if (shapePath !== undefined) {
                             shapePath
@@ -132,11 +137,13 @@ namespace Provider.Maps.Leaflet.Shape {
                         }
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillColor:
-                        this.provider.setStyle({ fillColor: value as string });
+                        this.provider.setStyle({
+                            fillColor: propertyValue as string
+                        });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillOpacity:
                         this.provider.setStyle({
-                            fillOpacity: value as number
+                            fillOpacity: propertyValue as number
                         });
                         return;
                 }

--- a/src/Providers/Maps/Leaflet/Shape/AbstractPolyshape.ts
+++ b/src/Providers/Maps/Leaflet/Shape/AbstractPolyshape.ts
@@ -106,8 +106,7 @@ namespace Provider.Maps.Leaflet.Shape {
             this.buildProvider(shapePath);
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
             super.changeProperty(propertyName, value);
@@ -115,7 +114,7 @@ namespace Provider.Maps.Leaflet.Shape {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Shape.locations:
                         // eslint-disable-next-line no-case-declarations
-                        const shapePath = this._buildPath(value);
+                        const shapePath = this._buildPath(value as string);
                         // If path is undefined (should be a promise) -> don't create the shape
                         if (shapePath !== undefined) {
                             shapePath
@@ -133,10 +132,12 @@ namespace Provider.Maps.Leaflet.Shape {
                         }
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillColor:
-                        this.provider.setStyle({ fillColor: value });
+                        this.provider.setStyle({ fillColor: value as string });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillOpacity:
-                        this.provider.setStyle({ fillOpacity: value });
+                        this.provider.setStyle({
+                            fillOpacity: value as number
+                        });
                         return;
                 }
             }

--- a/src/Providers/Maps/Leaflet/Shape/AbstractProviderShape.ts
+++ b/src/Providers/Maps/Leaflet/Shape/AbstractProviderShape.ts
@@ -156,32 +156,41 @@ namespace Provider.Maps.Leaflet.Shape {
             );
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Shape.allowDrag:
                         this._setDragEditConfigs(
-                            value as boolean,
+                            propertyValue as boolean,
                             this.config.allowEdit
                         );
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.allowEdit:
                         this._setDragEditConfigs(
                             this.config.allowDrag,
-                            value as boolean
+                            propertyValue as boolean
                         );
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.strokeOpacity:
-                        this.provider.setStyle({ opacity: value as number });
+                        this.provider.setStyle({
+                            opacity: propertyValue as number
+                        });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.strokeColor:
-                        this.provider.setStyle({ color: value as string });
+                        this.provider.setStyle({
+                            color: propertyValue as string
+                        });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.strokeWeight:
-                        this.provider.setStyle({ weight: value as number });
+                        this.provider.setStyle({
+                            weight: propertyValue as number
+                        });
                         return;
                 }
             }

--- a/src/Providers/Maps/Leaflet/Shape/AbstractProviderShape.ts
+++ b/src/Providers/Maps/Leaflet/Shape/AbstractProviderShape.ts
@@ -31,7 +31,7 @@ namespace Provider.Maps.Leaflet.Shape {
         ): void {
             // Using any here because the enableEdit(), disableEdit() methods and dragging property are not available on the default L (leaflet) library and we need to exclusively use the mentioned methods
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const providerShape: any = this.provider;
+            const providerShape = this.provider as any;
             allowEdit
                 ? providerShape.enableEdit()
                 : providerShape.disableEdit();
@@ -156,27 +156,32 @@ namespace Provider.Maps.Leaflet.Shape {
             );
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
             super.changeProperty(propertyName, value);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Shape.allowDrag:
-                        this._setDragEditConfigs(value, this.config.allowEdit);
+                        this._setDragEditConfigs(
+                            value as boolean,
+                            this.config.allowEdit
+                        );
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.allowEdit:
-                        this._setDragEditConfigs(this.config.allowDrag, value);
+                        this._setDragEditConfigs(
+                            this.config.allowDrag,
+                            value as boolean
+                        );
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.strokeOpacity:
-                        this.provider.setStyle({ opacity: value });
+                        this.provider.setStyle({ opacity: value as number });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.strokeColor:
-                        this.provider.setStyle({ color: value });
+                        this.provider.setStyle({ color: value as string });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.strokeWeight:
-                        this.provider.setStyle({ weight: value });
+                        this.provider.setStyle({ weight: value as number });
                         return;
                 }
             }

--- a/src/Providers/Maps/Leaflet/Shape/Circle.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Circle.ts
@@ -121,15 +121,20 @@ namespace Provider.Maps.Leaflet.Shape {
             super.buildProvider(shapeCenter);
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Shape.center:
                         // eslint-disable-next-line no-case-declarations
-                        const shapeCenter = this._buildCenter(value as string);
+                        const shapeCenter = this._buildCenter(
+                            propertyValue as string
+                        );
                         // If path is undefined (should be a promise) -> don't create the shape
                         if (shapeCenter !== undefined) {
                             shapeCenter
@@ -147,14 +152,16 @@ namespace Provider.Maps.Leaflet.Shape {
                         }
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.radius:
-                        this.provider.setRadius(value as number);
+                        this.provider.setRadius(propertyValue as number);
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillColor:
-                        this.provider.setStyle({ fillColor: value as string });
+                        this.provider.setStyle({
+                            fillColor: propertyValue as string
+                        });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillOpacity:
                         this.provider.setStyle({
-                            fillOpacity: value as number
+                            fillOpacity: propertyValue as number
                         });
                         return;
                 }

--- a/src/Providers/Maps/Leaflet/Shape/Circle.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Circle.ts
@@ -13,7 +13,7 @@ namespace Provider.Maps.Leaflet.Shape {
             map: OSFramework.Maps.OSMap.IMap,
             shapeId: string,
             type: OSFramework.Maps.Enum.ShapeType,
-            configs: JSON
+            configs: OSFramework.Maps.Configuration.IConfigurationShape
         ) {
             super(
                 map,
@@ -94,7 +94,10 @@ namespace Provider.Maps.Leaflet.Shape {
         protected createProvider(
             center: OSFramework.Maps.OSStructures.OSMap.Coordinates
         ): L.Circle {
-            return new L.Circle(center, this.getProviderConfig());
+            return new L.Circle(
+                center,
+                this.getProviderConfig() as L.CircleOptions
+            );
         }
 
         protected getShapeCoordinates(): OSFramework.Maps.OSStructures.OSMap.CircleCoordinates {
@@ -118,8 +121,7 @@ namespace Provider.Maps.Leaflet.Shape {
             super.buildProvider(shapeCenter);
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
             super.changeProperty(propertyName, value);
@@ -127,7 +129,7 @@ namespace Provider.Maps.Leaflet.Shape {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Shape.center:
                         // eslint-disable-next-line no-case-declarations
-                        const shapeCenter = this._buildCenter(value);
+                        const shapeCenter = this._buildCenter(value as string);
                         // If path is undefined (should be a promise) -> don't create the shape
                         if (shapeCenter !== undefined) {
                             shapeCenter
@@ -145,13 +147,15 @@ namespace Provider.Maps.Leaflet.Shape {
                         }
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.radius:
-                        this.provider.setRadius(value);
+                        this.provider.setRadius(value as number);
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillColor:
-                        this.provider.setStyle({ fillColor: value });
+                        this.provider.setStyle({ fillColor: value as string });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillOpacity:
-                        this.provider.setStyle({ fillOpacity: value });
+                        this.provider.setStyle({
+                            fillOpacity: value as number
+                        });
                         return;
                 }
             }

--- a/src/Providers/Maps/Leaflet/Shape/Factory.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Factory.ts
@@ -5,7 +5,7 @@ namespace Provider.Maps.Leaflet.Shape {
             map: OSFramework.Maps.OSMap.IMap,
             shapeId: string,
             type: OSFramework.Maps.Enum.ShapeType,
-            configs: JSON
+            configs: OSFramework.Maps.Configuration.IConfigurationShape
         ): OSFramework.Maps.Shape.IShape {
             switch (type) {
                 case OSFramework.Maps.Enum.ShapeType.Polygon:

--- a/src/Providers/Maps/Leaflet/Shape/Polygon.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Polygon.ts
@@ -10,7 +10,7 @@ namespace Provider.Maps.Leaflet.Shape {
             map: OSFramework.Maps.OSMap.IMap,
             shapeId: string,
             type: OSFramework.Maps.Enum.ShapeType,
-            configs: JSON
+            configs: OSFramework.Maps.Configuration.IConfigurationShape
         ) {
             super(
                 map,

--- a/src/Providers/Maps/Leaflet/Shape/Polyline.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Polyline.ts
@@ -10,7 +10,7 @@ namespace Provider.Maps.Leaflet.Shape {
             map: OSFramework.Maps.OSMap.IMap,
             shapeId: string,
             type: OSFramework.Maps.Enum.ShapeType,
-            configs: JSON
+            configs: OSFramework.Maps.Configuration.IConfigurationShape
         ) {
             super(
                 map,

--- a/src/Providers/Maps/Leaflet/Shape/Rectangle.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Rectangle.ts
@@ -151,23 +151,30 @@ namespace Provider.Maps.Leaflet.Shape {
             super.buildProvider(bounds);
         }
 
-        public changeProperty(propertyName: string, value: unknown): void {
+        public changeProperty(
+            propertyName: string,
+            propertyValue: unknown
+        ): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
-            super.changeProperty(propertyName, value);
+            super.changeProperty(propertyName, propertyValue);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillColor:
-                        this.provider.setStyle({ fillColor: value as string });
+                        this.provider.setStyle({
+                            fillColor: propertyValue as string
+                        });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillOpacity:
                         this.provider.setStyle({
-                            fillOpacity: value as number
+                            fillOpacity: propertyValue as number
                         });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.bounds:
                         // eslint-disable-next-line no-case-declarations
-                        const shapeBounds = this._buildBounds(value as string);
+                        const shapeBounds = this._buildBounds(
+                            propertyValue as string
+                        );
                         // If path is undefined (should be a promise) -> don't create the shape
                         if (shapeBounds !== undefined) {
                             shapeBounds

--- a/src/Providers/Maps/Leaflet/Shape/Rectangle.ts
+++ b/src/Providers/Maps/Leaflet/Shape/Rectangle.ts
@@ -13,8 +13,7 @@ namespace Provider.Maps.Leaflet.Shape {
             map: OSFramework.Maps.OSMap.IMap,
             shapeId: string,
             type: OSFramework.Maps.Enum.ShapeType,
-            // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-            configs: any
+            configs: OSFramework.Maps.Configuration.IConfigurationShape
         ) {
             super(
                 map,
@@ -126,7 +125,7 @@ namespace Provider.Maps.Leaflet.Shape {
                 [bounds.north, bounds.east]
             ];
             return new L.Rectangle(providerBounds, {
-                ...this.getProviderConfig()
+                ...(this.getProviderConfig() as L.PolylineOptions)
             });
         }
 
@@ -152,22 +151,23 @@ namespace Provider.Maps.Leaflet.Shape {
             super.buildProvider(bounds);
         }
 
-        // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-        public changeProperty(propertyName: string, value: any): void {
+        public changeProperty(propertyName: string, value: unknown): void {
             const propValue =
                 OSFramework.Maps.Enum.OS_Config_Shape[propertyName];
             super.changeProperty(propertyName, value);
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillColor:
-                        this.provider.setStyle({ fillColor: value });
+                        this.provider.setStyle({ fillColor: value as string });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.fillOpacity:
-                        this.provider.setStyle({ fillOpacity: value });
+                        this.provider.setStyle({
+                            fillOpacity: value as number
+                        });
                         return;
                     case OSFramework.Maps.Enum.OS_Config_Shape.bounds:
                         // eslint-disable-next-line no-case-declarations
-                        const shapeBounds = this._buildBounds(value);
+                        const shapeBounds = this._buildBounds(value as string);
                         // If path is undefined (should be a promise) -> don't create the shape
                         if (shapeBounds !== undefined) {
                             shapeBounds


### PR DESCRIPTION
This PR is for improving the overall code of OutSystems Maps, by removing the type `any`, and doing small code improvements.

### What was happening
* The usage of `any` was quite widespread
* Some lint errors had not been fixed

### What was done
* Replaced the usage of `any` by appropriate type or simply by `unknown`
* Fixing some lint warnings
* Creating new types 
* Overall small improvements in the code


### Checklist
* [x] tested locally
* [ ] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

