### PR TITLE
ROU-4591: change how addresses are transformed into coordenates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,9 @@
 	},
 	"[jsonc]": {
 		"editor.defaultFormatter": "vscode.json-language-features"
+	},
+	"sonarlint.connectedMode.project": {
+		"connectionId": "outsystems",
+		"projectKey": "OutSystems_outsystems-maps"
 	}
 }

--- a/src/Providers/Maps/Google/Features/Center.ts
+++ b/src/Providers/Maps/Google/Features/Center.ts
@@ -75,10 +75,7 @@ namespace Provider.Maps.Google.Feature {
         }
 
         public updateCenter(location: string): void {
-            Helper.Conversions.ConvertToCoordinates(
-                location,
-                this._map.config.apiKey
-            )
+            Helper.Conversions.ConvertToCoordinates(location)
                 .then((response) => {
                     this._map.config.center = response;
                     this._initialCenter = response;

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -232,7 +232,9 @@ namespace Provider.Maps.Google.Marker {
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Marker.location:
-                        Helper.Conversions.ConvertToCoordinates(value)
+                        Helper.Conversions.ConvertToCoordinates(
+                            propertyValue as string
+                        )
                             .then((response) => {
                                 this._provider.setPosition({
                                     lat: response.lat,

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -86,8 +86,7 @@ namespace Provider.Maps.Google.Marker {
                 // Let's return a promise that will be resolved or rejected according to the result
                 return new Promise((resolve, reject) => {
                     Helper.Conversions.ConvertToCoordinates(
-                        this.config.location,
-                        this.map.config.apiKey
+                        this.config.location
                     )
                         .then((response) => {
                             markerOptions.position = {
@@ -232,10 +231,7 @@ namespace Provider.Maps.Google.Marker {
             if (this.isReady) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_Marker.location:
-                        Helper.Conversions.ConvertToCoordinates(
-                            value,
-                            this.map.config.apiKey
-                        )
+                        Helper.Conversions.ConvertToCoordinates(value)
                             .then((response) => {
                                 this._provider.setPosition({
                                     lat: response.lat,

--- a/src/Providers/Maps/Google/Shape/AbstractPolyshape.ts
+++ b/src/Providers/Maps/Google/Shape/AbstractPolyshape.ts
@@ -32,10 +32,7 @@ namespace Provider.Maps.Google.Shape {
                             return false;
                         }
 
-                        Helper.Conversions.ConvertToCoordinates(
-                            location,
-                            this.map.config.apiKey
-                        )
+                        Helper.Conversions.ConvertToCoordinates(location)
                             .then((response) => {
                                 shapePath.set(index, {
                                     lat: response.lat,

--- a/src/Providers/Maps/Google/Shape/Circle.ts
+++ b/src/Providers/Maps/Google/Shape/Circle.ts
@@ -37,10 +37,7 @@ namespace Provider.Maps.Google.Shape {
             }
 
             return new Promise((resolve, reject) => {
-                Helper.Conversions.ConvertToCoordinates(
-                    location,
-                    this.map.config.apiKey
-                )
+                Helper.Conversions.ConvertToCoordinates(location)
                     .then((response) => {
                         const coordinates = {
                             lat: response.lat,

--- a/src/Providers/Maps/Google/Shape/Rectangle.ts
+++ b/src/Providers/Maps/Google/Shape/Rectangle.ts
@@ -68,10 +68,7 @@ namespace Provider.Maps.Google.Shape {
                             resolve(newBounds);
                         }
                     } else {
-                        Helper.Conversions.ConvertToCoordinates(
-                            bounds[cd],
-                            this.map.config.apiKey
-                        )
+                        Helper.Conversions.ConvertToCoordinates(bounds[cd])
                             .then((response) => {
                                 boundsLength++;
                                 switch (cd) {

--- a/src/Providers/Maps/Google/SharedComponents/MapsAndSearchPlaces.ts
+++ b/src/Providers/Maps/Google/SharedComponents/MapsAndSearchPlaces.ts
@@ -90,7 +90,7 @@ namespace Provider.Maps.Google.SharedComponents {
                         resolve(finalBounds);
                     }
                 } else {
-                    Helper.Conversions.ConvertToCoordinates(bounds[cd], apiKey)
+                    Helper.Conversions.ConvertToCoordinates(bounds[cd])
                         .then((response) => {
                             // Make sure to increment the boundsLength to validate whether the bounds structure has all the cardinal directions or not.
                             boundsLength++;


### PR DESCRIPTION
This PR is for changing the way addresses are transformed into coordinates.

### What was happening
The transformation of the addresses, was using a google REST API, that implied making a fetch in the maps code. Additionally there were situations in which the translation of the addresses failed.

### What was done
* Change the code to start using the method `geo.geocode`, available out of the box in the Google Maps script.

### Test Steps
* Scenario 1
  * Open the screen
  * Click on the button Go to map
  * Click on the toggle above the map
    * First time the map will disappear
    * Second time the map will re-appear, but now running the new code
  * Start typing Rua de Santa Maria in the OutSystems Search Places
  * Notice that the map has changed the center of it

(The current code, **fails** to change the center of the map).


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

