### PR TITLE
ROU-4592: fixing google maps imprecision with markers

### DIFF
--- a/src/OSFramework/Maps/Helper/IsValidNumber.ts
+++ b/src/OSFramework/Maps/Helper/IsValidNumber.ts
@@ -1,0 +1,13 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.Maps.Helper {
+    /**
+     * Validates if value is a valid number.
+     *
+     * @export
+     * @param {unknown} value
+     * @return {*}  {boolean}
+     */
+    export function IsValidNumber(value: unknown): boolean {
+        return !isNaN(value as number);
+    }
+}

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -42,7 +42,8 @@ namespace Provider.Maps.Google.Marker {
                     // Else If nothing is passed or the icon size has the width or the height equal to 0, use the full image size
                     if (
                         OSFramework.Maps.Helper.IsValidNumber(height) &&
-                        OSFramework.Maps.Helper.IsValidNumber(width)
+                        OSFramework.Maps.Helper.IsValidNumber(width) && 
+                        height > 0 && width > 0
                     ) {
                         scaledSize = new google.maps.Size(width, height);
                     }

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -34,21 +34,22 @@ namespace Provider.Maps.Google.Marker {
             } else {
                 try {
                     let scaledSize: google.maps.Size;
+                    //Explicit conversion to number - related with ROU-4592 - as google will behave differently depending on the type
+                    //of the input. Before, in runtime, the input was of type string.
+                    const height = Number(this.config.iconHeight);
+                    const width = Number(this.config.iconWidth);
                     // If the size of the icon is defined by a valid width and height, use those values
                     // Else If nothing is passed or the icon size has the width or the height equal to 0, use the full image size
                     if (
-                        this.config.iconWidth > 0 &&
-                        this.config.iconHeight > 0
+                        OSFramework.Maps.Helper.IsValidNumber(height) &&
+                        OSFramework.Maps.Helper.IsValidNumber(width)
                     ) {
-                        scaledSize = new google.maps.Size(
-                            this.config.iconWidth,
-                            this.config.iconHeight
-                        );
+                        scaledSize = new google.maps.Size(width, height);
                     }
                     // Update the icon using the previous configurations
                     const icon = {
-                        url,
-                        scaledSize
+                        url: url,
+                        size: scaledSize
                     };
                     // Set the icon to the Marker provider
                     this.provider.setIcon(icon);


### PR DESCRIPTION
This PR is for fixing an issue that was occurring when providing icon and icon size to each, causing what appeared to be imprecision when clicking on the marker. 

This issue was initially reported in [OutSystems community](https://www.outsystems.com/forums/discussion/91716/outsystems-maps-marker-popup-issue-on-phone/), by [Walter Robins](https://www.outsystems.com/profile/ithrqirw96/overview), that kindly provided a sample, and a good analysis of the issue - greatly contributing to finding the issue.

### What was happening
* when custom icon and the size (width and height) were set into a marker, the click on the marker became imprecise, occasionally, specially with many marker imprecise, opening sometimes the wrong pop-up.
* When creating the instance of `new google.maps.Size()` the type of the input affects the type of unit Google will consider it to be:
  * The type in TypeScript of the `height` and `width` is `number`;
  * However, in runtime, `typeof this.config.iconHeight` was `string`

### What was done
* Added a helper function to validate is a given input is a valid number
* Force cast to number before passing into the creation of the instance of Size

### Test Steps
1. Open sample with many markers close together
2. Zoom into an area with several markers in proximity
3. Click on each marker, and check if the right pop-up is appearing


### Screenshots
(prefer animated gif)


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

