### PR TITLE
ROU-4665: allow preserving the zoom level when user changes it

### DIFF
--- a/src/OSFramework/Maps/Configuration/IConfigurationMap.ts
+++ b/src/OSFramework/Maps/Configuration/IConfigurationMap.ts
@@ -8,6 +8,7 @@ namespace OSFramework.Maps.Configuration {
         apiKey?: string;
         center: string | OSStructures.OSMap.Coordinates;
         height: string;
+        respectUserZoom?: boolean;
         type?: Enum.OSMap.Type;
         uniqueId: string;
         zoom: Enum.OSMap.Zoom;

--- a/src/OSFramework/Maps/Enum/OS_Config_Map.ts
+++ b/src/OSFramework/Maps/Enum/OS_Config_Map.ts
@@ -13,6 +13,7 @@ namespace OSFramework.Maps.Enum {
         markerClustererMinClusterSize,
         markerClustererZoomOnClick,
         offset,
+        respectUserZoom,
         showTraffic,
         staticMap,
         style,

--- a/src/OSFramework/Maps/OSMap/AbstractMap.ts
+++ b/src/OSFramework/Maps/OSMap/AbstractMap.ts
@@ -22,8 +22,10 @@ namespace OSFramework.Maps.OSMap {
         private _shapesSet: Set<Shape.IShape>;
         private _uniqueId: string;
         private _widgetId: string;
+        private _zoomChanged: boolean;
 
         protected _features: Feature.ExposedFeatures;
+        protected _mapZoomChangeCallback: Maps.Callbacks.Generic;
         protected _provider: W;
 
         constructor(
@@ -46,8 +48,14 @@ namespace OSFramework.Maps.OSMap {
             this._mapEvents = new Event.OSMap.MapEventsManager(this);
             this._mapType = mapType;
             this._providerType = providerType;
+            this._zoomChanged = false;
+            this._mapZoomChangeCallback = this._mapZoomChangeHandler.bind(this);
         }
         public abstract get mapTag(): string;
+
+        protected get allowRefreshZoom(): boolean {
+            return !(this.config.respectUserZoom && this._zoomChanged);
+        }
 
         protected get shapes(): Shape.IShape[] {
             return Array.from(this._shapesSet);
@@ -107,6 +115,12 @@ namespace OSFramework.Maps.OSMap {
 
         public get widgetId(): string {
             return this._widgetId;
+        }
+
+        private _mapZoomChangeHandler(): void {
+            if (this.config.respectUserZoom) {
+                this._zoomChanged = true;
+            }
         }
 
         protected finishBuild(): void {
@@ -173,6 +187,7 @@ namespace OSFramework.Maps.OSMap {
                     Maps.Enum.OS_Config_Map.respectUserZoom ===
                     Maps.Enum.OS_Config_Map[propertyName]
                 ) {
+                    this._zoomChanged = false;
                 }
             } else {
                 this.mapEvents.trigger(

--- a/src/OSFramework/Maps/OSMap/AbstractMap.ts
+++ b/src/OSFramework/Maps/OSMap/AbstractMap.ts
@@ -168,6 +168,12 @@ namespace OSFramework.Maps.OSMap {
             //Update Map's config when the property is available
             if (this.config.hasOwnProperty(propertyName)) {
                 this.config[propertyName] = propertyValue;
+
+                if (
+                    Maps.Enum.OS_Config_Map.respectUserZoom ===
+                    Maps.Enum.OS_Config_Map[propertyName]
+                ) {
+                }
             } else {
                 this.mapEvents.trigger(
                     Event.OSMap.MapEventType.OnError,

--- a/src/Providers/Maps/Google/Configuration/OSMap/GoogleMapConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/OSMap/GoogleMapConfig.ts
@@ -10,6 +10,7 @@ namespace Provider.Maps.Google.Configuration.OSMap {
         public height: string;
         public markerClusterer: OSFramework.Maps.Configuration.IConfigurationMarkerClusterer;
         public offset: OSFramework.Maps.OSStructures.OSMap.Offset;
+        public respectUserZoom: boolean;
         public showTraffic: boolean;
         public style: OSFramework.Maps.Enum.OSMap.Style;
         public type: OSFramework.Maps.Enum.OSMap.Type;

--- a/src/Providers/Maps/Google/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Google/OSMap/OSMap.ts
@@ -28,6 +28,14 @@ namespace Provider.Maps.Google.OSMap {
         }
 
         private _addMapZoomHandler(): void {
+            /*
+                This timeout is here due to an anomaly in the behaviour of google maps
+                when more than one maker is added to the map, the zoom event is fired twice:
+                https://stackoverflow.com/questions/20436185/google-maps-api-v3-zoom-changed-event-fired-twice-after-fitbounds-called
+
+                However since the event is triggered asynchronously and there's no way
+                to wait for it, or to know it will occur, this hack was added. I'm sorry, I'm ashamed of myself. 
+            */
             setTimeout(() => {
                 if (this && this._provider) {
                     this._gZoomChangeListener = google.maps.event.addListener(

--- a/src/Providers/Maps/Google/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Google/OSMap/OSMap.ts
@@ -511,8 +511,10 @@ namespace Provider.Maps.Google.OSMap {
             // Refresh the center position
             this.features.center.refreshCenter(position);
 
-            // Refresh the zoom
-            this.features.zoom.refreshZoom();
+            if (this.allowRefreshZoom) {
+                // Refresh the zoom
+                this.features.zoom.refreshZoom();
+            }
 
             // Refresh the offset
             this.features.offset.setOffset(this.features.offset.getOffset);

--- a/src/Providers/Maps/Leaflet/Configuration/OSMap/LeafletMapConfiguration.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/OSMap/LeafletMapConfiguration.ts
@@ -7,6 +7,7 @@ namespace Provider.Maps.Leaflet.Configuration.OSMap {
         public center: string | OSFramework.Maps.OSStructures.OSMap.Coordinates;
         public height: string;
         public offset: OSFramework.Maps.OSStructures.OSMap.Offset;
+        public respectUserZoom: boolean;
         public uniqueId: string;
         public zoom: OSFramework.Maps.Enum.OSMap.Zoom;
 

--- a/src/Providers/Maps/Leaflet/Constants/OSMap/Events.ts
+++ b/src/Providers/Maps/Leaflet/Constants/OSMap/Events.ts
@@ -22,6 +22,7 @@ namespace Provider.Maps.Leaflet.Constants.OSMap {
         tilesloaded = 'load',
         load = 'load',
         zoom_changed = 'zoom',
+        zoom_end = 'zoomend',
         zoom = 'zoom'
     }
 }

--- a/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
@@ -373,8 +373,10 @@ namespace Provider.Maps.Leaflet.OSMap {
             // Refresh the center position
             this.features.center.refreshCenter(position);
 
-            // Refresh the zoom
-            this.features.zoom.refreshZoom();
+            if (this.allowRefreshZoom) {
+                // Refresh the zoom
+                this.features.zoom.refreshZoom();
+            }
 
             // Refresh the offset
             this.features.offset.setOffset(this.features.offset.getOffset);

--- a/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
@@ -32,6 +32,13 @@ namespace Provider.Maps.Leaflet.OSMap {
             );
         }
 
+        private _addMapZoomHandler(): void {
+            this._provider.on(
+                Constants.OSMap.ProviderEventNames.zoom_end,
+                this._mapZoomChangeCallback
+            );
+        }
+
         private _buildDrawingTools(): void {
             // Here we aren't using a forEach because there is only one drawingTools per map
             this.drawingTools && this.drawingTools.build();
@@ -51,6 +58,13 @@ namespace Provider.Maps.Leaflet.OSMap {
                 OSFramework.Maps.Helper.Constants.defaultMapCenter;
 
             return this.config.getProviderConfig();
+        }
+
+        private _removeMapZoomHandler(): void {
+            this._provider.off(
+                Constants.OSMap.ProviderEventNames.zoom_end,
+                this._mapZoomChangeCallback
+            );
         }
 
         private _setMapEvents(): void {
@@ -189,6 +203,8 @@ namespace Provider.Maps.Leaflet.OSMap {
             // Make sure to change the center after the conversion of the location to coordinates
             this.features.center.updateCenter(currentCenter as string);
             this._setMapEvents();
+
+            this._addMapZoomHandler();
         }
 
         public buildFeatures(): void {
@@ -317,6 +333,8 @@ namespace Provider.Maps.Leaflet.OSMap {
         }
 
         public refresh(): void {
+            this._removeMapZoomHandler();
+
             let position = this.features.center.getCenter();
             // When the position is empty, we use the default position
             // If the configured center position of the map is equal to the default
@@ -364,6 +382,8 @@ namespace Provider.Maps.Leaflet.OSMap {
             // Repaint the marker Clusterers
             this.hasMarkerClusterer() &&
                 this.features.markerClusterer.repaint();
+
+            this._addMapZoomHandler();
         }
 
         public refreshProviderEvents(): void {

--- a/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
@@ -333,6 +333,7 @@ namespace Provider.Maps.Leaflet.OSMap {
         }
 
         public refresh(): void {
+            //Let's stop listening to the zoom event be caused by the refreshZoom
             this._removeMapZoomHandler();
 
             let position = this.features.center.getCenter();
@@ -375,6 +376,7 @@ namespace Provider.Maps.Leaflet.OSMap {
             this.hasMarkerClusterer() &&
                 this.features.markerClusterer.repaint();
 
+            //Re-adding the map zoom handler
             this._addMapZoomHandler();
         }
 

--- a/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
@@ -336,38 +336,28 @@ namespace Provider.Maps.Leaflet.OSMap {
             this._removeMapZoomHandler();
 
             let position = this.features.center.getCenter();
-            // When the position is empty, we use the default position
-            // If the configured center position of the map is equal to the default
-            const isDefault =
-                position.lat ===
-                    OSFramework.Maps.Helper.Constants.defaultMapCenter.lat &&
-                position.lng ===
-                    OSFramework.Maps.Helper.Constants.defaultMapCenter.lng;
-            // If the Map has the default center position and at least 1 Marker, we want to use the first Marker position as the new center of the Map
-            if (
-                isDefault === true &&
-                this.markers.length >= 1 &&
-                this.markers[0].provider !== undefined
-            ) {
-                position = this.markers[0].provider.getLatLng();
-            }
-            // If the Map has NOT the default center position and EXACTLY 1 Marker, we want to use the first Marker position as the new center of the Map
-            else if (
-                isDefault === false &&
-                this.markers.length === 1 &&
-                this.markers[0].provider !== undefined
-            ) {
-                position = this.markers[0].provider.getLatLng();
-            }
-            // If the Map has NOT the default center position, 2 or more Markers and the zoom is set to be AutoFit
-            // we want to use the first Marker position as the new center of the Map
-            else if (
-                isDefault === false &&
-                this.markers.length >= 2 &&
-                this.markers[0].provider !== undefined &&
-                this.features.zoom.isAutofit
-            ) {
-                position = this.markers[0].provider.getLatLng();
+
+            //If there are markers, let's choose the map center accordingly.
+            //Otherwise, the map center will be the one defined in the configs.
+            if (this.markers.length > 0) {
+                if (this.markers.length > 1) {
+                    //As the map has more than one marker, let's see if the map
+                    //center should be changed.
+                    if (this.allowRefreshZoom) {
+                        //If the user hasn't change zoom, or the developer is ignoring
+                        //it (current behavior), then the map will be centered tentatively
+                        //in the first marker.
+                        position = this.markers[0].provider.getLatLng();
+                    } else {
+                        //If the user has zoomed and the developer intends to respect user zoom
+                        //then the current map center will be used.
+                        position = this.provider.getCenter();
+                    }
+                } else if (this.markers[0].provider !== undefined) {
+                    //If there's only one marker, and is already created, its location will be
+                    //used as the map center.
+                    position = this.markers[0].provider.getLatLng();
+                }
             }
 
             // Refresh the center position


### PR DESCRIPTION
This PR is adding the capacity for the map to respect the user changes on the zoom, when map center is changed, or markers are added, changed, removed. 

### What was happening
* The zoom was being reset whenever any change to the map that caused a refresh in it occurred.
* The scenarios when the reset occurred were:
   * the center of the map changed (and there were no markers)
   * the center of a marker changed
   * a marker was added
   * a marker was removed

### What was done
* Added new optional config in the map: `RespectUserZoom` (default: false - current behavior)
* Added listener to zoom_changed (google maps) / zoom_end (leaflet) event
* Added flag to understand when the user scrolls `_zoomChanged`
* Blocked refreshZoom when `RespectUserZoom` config and `_zoomChanged` flag are set to true

### Test Steps
1. Automatic tests were created

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

