### PR TITLE
ROU-4709: Fixing cluster problems with back-button, other improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
 	"files.autoSave": "off",
 	"editor.minimap.maxColumn": 170,
 	"editor.wordWrapColumn": 170,
-	"editor.formatOnSave": true,
+	"editor.formatOnSave": false,
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": "explicit"
 	},

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
 	"files.autoSave": "off",
 	"editor.minimap.maxColumn": 170,
 	"editor.wordWrapColumn": 170,
-	"editor.formatOnSave": false,
+	"editor.formatOnSave": true,
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": "explicit"
 	},

--- a/src/OSFramework/Maps/Feature/IMarkerClusterer.ts
+++ b/src/OSFramework/Maps/Feature/IMarkerClusterer.ts
@@ -4,7 +4,7 @@ namespace OSFramework.Maps.Feature {
         /** Checks if the marker clusterer feature is activated */
         isEnabled: boolean;
         /** Gets the marker  */
-        markerClusterer: MarkerClusterer;
+        markerClusterer: GoogleMapsMarkerClusterer;
         /**
          * Adds a marker into the cluster
          * @param marker Marker Object from OSFramework that is going to be added into the cluster

--- a/src/OSFramework/Maps/Helper/Constants.ts
+++ b/src/OSFramework/Maps/Helper/Constants.ts
@@ -110,7 +110,7 @@ namespace OSFramework.Maps.Helper.Constants {
     export const googleMapsApiMap = `${googleMapsApiURL}/js`;
     /** URL for GoogleMaps API to make use of the Google StaticMap */
     export const googleMapsApiStaticMap = `${googleMapsApiURL}/staticmap`;
-    /** Version of the google maps to be loaded. */
+    /** Version of the Google Maps to be loaded. */
     export const gmversion = "3.55"; //Stable version Mid-February 2024.
     // In order to use the drawingTools we need to add it into the libraries via the URL = drawing
     // In order to use the heatmap we need to add it into the libraries via the URL = visualization

--- a/src/OSFramework/Maps/Helper/Constants.ts
+++ b/src/OSFramework/Maps/Helper/Constants.ts
@@ -106,12 +106,16 @@ namespace OSFramework.Maps.Helper.Constants {
     /** URL for GoogleMapsApis  */
     /************************** */
     export const googleMapsApiURL = 'https://maps.googleapis.com/maps/api';
-    /** URL for GoogleMaps API to get coordinates by Address/Location */
-    export const googleMapsApiGeocode = `${googleMapsApiURL}/geocode/json`;
     /** URL for GoogleMaps API to make use of the Google Map */
     export const googleMapsApiMap = `${googleMapsApiURL}/js`;
     /** URL for GoogleMaps API to make use of the Google StaticMap */
     export const googleMapsApiStaticMap = `${googleMapsApiURL}/staticmap`;
+    /** Version of the google maps to be loaded. */
+    export const gmversion = "3.55"; //Stable version Mid-February 2024.
+    // In order to use the drawingTools we need to add it into the libraries via the URL = drawing
+    // In order to use the heatmap we need to add it into the libraries via the URL = visualization
+    // In order to use the searchplaces we need to add it into the libraries via the URL = places (in case the Map is the first to import the scripts)                
+    export const gmlibraries = "drawing,visualization,places";
 
     /******************** */
     /** URLs for Leaflet  */

--- a/src/OSFramework/Maps/Marker/AbstractMarker.ts
+++ b/src/OSFramework/Maps/Marker/AbstractMarker.ts
@@ -12,6 +12,7 @@ namespace OSFramework.Maps.Marker {
         private _widgetId: string;
 
         protected _built: boolean;
+        protected _destroyed: boolean;
         protected _markerEvents: Event.Marker.MarkerEventsManager;
         protected _provider: W;
 
@@ -27,6 +28,7 @@ namespace OSFramework.Maps.Marker {
             this._uniqueId = uniqueId;
             this._config = config;
             this._built = false;
+            this._destroyed = false;
             this._markerEvents = new Event.Marker.MarkerEventsManager(this);
         }
         public abstract get markerTag(): string;
@@ -101,6 +103,7 @@ namespace OSFramework.Maps.Marker {
 
         public dispose(): void {
             this._built = false;
+            this._destroyed = true;
         }
 
         public equalsToID(id: string): boolean {

--- a/src/OutSystems/Maps/MapAPI/MapManager.ts
+++ b/src/OutSystems/Maps/MapAPI/MapManager.ts
@@ -244,7 +244,7 @@ namespace OutSystems.Maps.MapAPI.MapManager {
 
     /**
      * Sets the Renderer object to create the clusters. If undefined if passed the default render will be used.
-     * Available for google maps only. See examples in https://googlemaps.github.io/js-markerclusterer/public/renderers/.
+     * Available for Google Maps only. See examples in https://googlemaps.github.io/js-markerclusterer/public/renderers/.
      *
      * @export
      * @param {string} mapId

--- a/src/Providers/Maps/Google/Configuration/MarkerClusterer/MarkerClustererConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/MarkerClusterer/MarkerClustererConfig.ts
@@ -10,11 +10,11 @@ namespace Provider.Maps.Google.Configuration.MarkerClusterer {
         public markerClustererMinClusterSize: number;
         public markerClustererZoomOnClick: boolean;
 
-        constructor(
-            config: Configuration.MarkerClusterer.MarkerClustererConfig
-        ) {
-            super(config);
-        }
+        // constructor(
+        //     config: Configuration.MarkerClusterer.MarkerClustererConfig
+        // ) {
+        //     super(config);
+        // }
 
         public getProviderConfig(): GoogleMapsMarkerClustererOptions {
             return {};

--- a/src/Providers/Maps/Google/Configuration/MarkerClusterer/MarkerClustererConfig.ts
+++ b/src/Providers/Maps/Google/Configuration/MarkerClusterer/MarkerClustererConfig.ts
@@ -4,8 +4,6 @@ namespace Provider.Maps.Google.Configuration.MarkerClusterer {
         extends OSFramework.Maps.Configuration.AbstractConfiguration
         implements OSFramework.Maps.Configuration.IConfigurationMarkerClusterer
     {
-        private _map: Provider.Maps.Google.OSMap.IMapGoogle;
-        private _renderer: GoogleClusterRenderer;
         public clusterClass: string;
         public markerClustererActive: boolean;
         public markerClustererMaxZoom: number;
@@ -13,49 +11,13 @@ namespace Provider.Maps.Google.Configuration.MarkerClusterer {
         public markerClustererZoomOnClick: boolean;
 
         constructor(
-            config: Configuration.MarkerClusterer.MarkerClustererConfig,
-            map: Provider.Maps.Google.OSMap.IMapGoogle
+            config: Configuration.MarkerClusterer.MarkerClustererConfig
         ) {
             super(config);
-            this._map = map;
-            this._renderer = new window.markerClusterer.DefaultRenderer();
         }
 
-        public set renderer(renderer: OSFramework.Maps.Feature.IMarkerClustererRender) {
-            if (renderer !== undefined) {
-                this._renderer = renderer as GoogleClusterRenderer;
-            } else {
-                this._renderer = new window.markerClusterer.DefaultRenderer();
-            }
-        }
-
-        public getProviderConfig(): MarkerClustererOptions {
-            const minPoints = this.markerClustererActive ? this.markerClustererMinClusterSize : Number.MAX_SAFE_INTEGER;
-            // eslint-disable-next-line prefer-const
-            let provider = {
-                algorithm: new window.markerClusterer.SuperClusterAlgorithm({
-                    maxZoom: this.markerClustererMaxZoom || 2,
-                    minPoints: minPoints,
-                }),
-                algorithmOptions: undefined,
-                map: this._map.provider,
-                markers: this._map.markersReady as google.maps.Marker[],
-                onClusterClick: (event: google.maps.MapMouseEvent, cluster: Cluster, map: google.maps.Map) => {
-                    if (this.markerClustererZoomOnClick) {
-                        map.fitBounds(cluster.bounds);
-                    }
-                },
-                renderer: this._renderer,
-            };
-
-            //Cleaning undefined properties
-            Object.keys(provider).forEach((key) => {
-                if (provider[key] === undefined) {
-                    delete provider[key];
-                }
-            });
-
-            return provider;
+        public getProviderConfig(): GoogleMapsMarkerClustererOptions {
+            return {};
         }
     }
 }

--- a/src/Providers/Maps/Google/Features/GoogleMarkerClusterer.ts
+++ b/src/Providers/Maps/Google/Features/GoogleMarkerClusterer.ts
@@ -20,8 +20,7 @@ namespace Provider.Maps.Google.Feature {
             // Set the clusterer configs
             this._config =
                 new Configuration.MarkerClusterer.MarkerClustererConfig(
-                    markerClustererConfigs,
-                    this._map
+                    markerClustererConfigs
                 );
         }
 

--- a/src/Providers/Maps/Google/Features/GoogleMarkerClusterer.ts
+++ b/src/Providers/Maps/Google/Features/GoogleMarkerClusterer.ts
@@ -25,7 +25,7 @@ namespace Provider.Maps.Google.Feature {
                 );
         }
 
-        public get markerClusterer(): MarkerClusterer {
+        public get markerClusterer(): GoogleMapsMarkerClusterer {
             return this._markerClusterer;
         }
 

--- a/src/Providers/Maps/Google/Features/GoogleMarkerClusterer.ts
+++ b/src/Providers/Maps/Google/Features/GoogleMarkerClusterer.ts
@@ -126,14 +126,15 @@ namespace Provider.Maps.Google.Feature {
             if (this.markerClusterer !== undefined) {
                 switch (propValue) {
                     case OSFramework.Maps.Enum.OS_Config_MarkerClusterer.markerClustererActive:
-                        this._setState(propertyValue as boolean);
+                        this._setState();
                         break;
                     case OSFramework.Maps.Enum.OS_Config_MarkerClusterer.markerClustererMinClusterSize:
-                        this._rebuildClusters();
-                        break;
                     case OSFramework.Maps.Enum.OS_Config_MarkerClusterer.markerClustererMaxZoom:
+                        this._makeAlgorithm();
                         this._rebuildClusters();
                         break;
+                    case OSFramework.Maps.Enum.OS_Config_MarkerClusterer.markerClustererZoomOnClick:
+                        return;
                 }
                 this.repaint();
             }

--- a/src/Providers/Maps/Google/Features/InfoWindow.ts
+++ b/src/Providers/Maps/Google/Features/InfoWindow.ts
@@ -15,7 +15,7 @@ namespace Provider.Maps.Google.Feature {
 
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         public build(): void {
-            // Creates an instance of the infoWindow object from google maps api
+            // Creates an instance of the infoWindow object from Google Maps api
             // We need to specify the content, so let's make it an empty string
             // This content will be updated whenever a marker with popup is clicked
             this._infoWindow = new google.maps.InfoWindow({

--- a/src/Providers/Maps/Google/Global.d.ts
+++ b/src/Providers/Maps/Google/Global.d.ts
@@ -3,7 +3,8 @@ import {
     MarkerClusterer as OriginalMarkerClusterer,
     MarkerClustererOptions as OriginalMarkerClustererOptions,
     SuperClusterAlgorithm as OriginalSuperClusterAlgorithm, Cluster as OriginalCluster,
-    Renderer as OriginalRenderer
+    Renderer as OriginalRenderer,
+    Algorithm as OriginalAlgorithm
 } from '@googlemaps/markerclusterer';
 
 declare global {
@@ -17,10 +18,11 @@ declare global {
         }; 
     }
     //The types below, are useful for TypeScript intellisense.
-    type Cluster = OriginalCluster;
-    type MarkerClusterer = OriginalMarkerClusterer;
-    type MarkerClustererOptions = OriginalMarkerClustererOptions;
-    type GoogleClusterRenderer = OriginalRenderer;
-    type SuperClusterAlgorithm = OriginalSuperClusterAlgorithm;
+    type GoogleMapsAlgorithm = OriginalAlgorithm;
+    type GoogleMapsCluster = OriginalCluster;
+    type GoogleMapsMarkerClusterer = OriginalMarkerClusterer;
+    type GoogleMapsMarkerClustererOptions = OriginalMarkerClustererOptions;
+    type GoogleMapsClusterRenderer = OriginalRenderer;
+    type GoogleMapsSuperClusterAlgorithm = OriginalSuperClusterAlgorithm;
 }
 window.GMCB = window.GMCB || {};

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -194,6 +194,9 @@ namespace Provider.Maps.Google.Marker {
             if (markerPosition !== undefined) {
                 markerPosition
                     .then((markerOptions) => {
+                        //The marker was destroyed while waiting for the promise.
+                        if(this._destroyed) return;
+
                         this._provider = new google.maps.Marker({
                             ...(this.getProviderConfig() as unknown[]),
                             ...markerOptions,

--- a/src/Providers/Maps/Google/Marker/MarkerPopup.ts
+++ b/src/Providers/Maps/Google/Marker/MarkerPopup.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../../../OSFramework/Maps/Marker/AbstractMarker.ts" />
+/// <reference path="Marker.ts" />
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace Provider.Maps.Google.Marker {

--- a/src/Providers/Maps/Google/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Google/OSMap/OSMap.ts
@@ -30,7 +30,7 @@ namespace Provider.Maps.Google.OSMap {
 
         private _addMapZoomHandler(): void {
             /*
-                This timeout is here due to an anomaly in the behaviour of google maps
+                This timeout is here due to an anomaly in the behaviour of Google Maps
                 when more than one maker is added to the map, the zoom event is fired twice:
                 https://stackoverflow.com/questions/20436185/google-maps-api-v3-zoom-changed-event-fired-twice-after-fitbounds-called
 
@@ -188,7 +188,7 @@ namespace Provider.Maps.Google.OSMap {
 
             // Other Provider Events (OS Map Event Block)
             // Any events that got added to the mapEvents via the API Subscribe method will have to be taken care here
-            // If the Event type of each handler is MapProviderEvent, we want to make sure to add that event to the listeners of the google maps provider (e.g. click, dblclick, contextmenu, etc)
+            // If the Event type of each handler is MapProviderEvent, we want to make sure to add that event to the listeners of the Google Maps provider (e.g. click, dblclick, contextmenu, etc)
             this.mapEvents.handlers.forEach(
                 (
                     handler: OSFramework.Maps.Event.IEvent<OSFramework.Maps.OSMap.IMap>,

--- a/src/Providers/Maps/Google/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Google/OSMap/OSMap.ts
@@ -486,17 +486,30 @@ namespace Provider.Maps.Google.OSMap {
 
             let position = this.features.center.getCenter();
 
+            const isDefault =
+                position.lat ===
+                    OSFramework.Maps.Helper.Constants.defaultMapCenter.lat &&
+                position.lng ===
+                    OSFramework.Maps.Helper.Constants.defaultMapCenter.lng;
+
             //If there are markers, let's choose the map center accordingly.
             //Otherwise, the map center will be the one defined in the configs.
             if (this.markers.length > 0) {
                 if (this.markers.length > 1) {
                     //As the map has more than one marker, let's see if the map
                     //center should be changed.
+                    //If the user hasn't change zoom, or the developer is ignoring it (current behavior).
                     if (this.allowRefreshZoom) {
-                        //If the user hasn't change zoom, or the developer is ignoring
-                        //it (current behavior), then the map will be centered tentatively
-                        //in the first marker.
-                        position = this.markers[0].provider.position.toJSON();
+                        //Let's check if the marker provider is ready to be used.
+                        if(this.markers[0].provider !== undefined){
+                            //If the map center, is the same as the default, then the map will ignore it.
+                            //Otherwise, the isAutofit config will be checked, and if false, then the current
+                            //center will not be changed.
+                            if(isDefault || this.features.zoom.isAutofit) {
+                                //Let's use the first marker as the center of the map.
+                                position = this.markers[0].provider.position.toJSON();
+                            }
+                        }
                     } else {
                         //If the user has zoomed and the developer intends to respect user zoom
                         //then the current map center will be used.

--- a/src/Providers/Maps/Google/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Google/OSMap/OSMap.ts
@@ -91,9 +91,6 @@ namespace Provider.Maps.Google.OSMap {
                 );
             }
 
-            if (this._scriptCallback !== undefined) {
-                script.removeEventListener('load', this._scriptCallback);
-            }
             if (typeof google === 'object' && typeof google.maps === 'object') {
                 // Make sure the center is saved before setting a default value which is going to be used
                 // before the conversion of the location to coordinates gets resolved

--- a/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
@@ -204,7 +204,7 @@ namespace Provider.Maps.Google.SearchPlaces {
             }
         }
 
-        /** If countries > 5 (as required by google maps api), throw an error an return false */
+        /** If countries > 5 (as required by Google Maps api), throw an error an return false */
         private _validCountriesMaxLength(countries: Array<string>): boolean {
             if (countries.length > 5) {
                 this.searchPlacesEvents.trigger(

--- a/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
@@ -80,9 +80,6 @@ namespace Provider.Maps.Google.SearchPlaces {
                 );
             }
 
-            if (this._scriptCallback !== undefined) {
-                script.removeEventListener('load', this._scriptCallback);
-            }
             if (typeof google === 'object' && typeof google.maps === 'object') {
                 const local_configs =
                     this.getProviderConfig() as Configuration.SearchPlaces.ISearchPlacesProviderConfig;

--- a/src/Providers/Maps/Google/SharedComponents/MapsAndSearchPlaces.ts
+++ b/src/Providers/Maps/Google/SharedComponents/MapsAndSearchPlaces.ts
@@ -20,7 +20,7 @@ namespace Provider.Maps.Google.SharedComponents {
                     window.GMCB = () => {
                         //this method is just to avoid unnecessary warning on the console;
                         window.GMCB = undefined;
-                        resolve(undefined);
+                        resolve(0);
                         googleMapsLoadPromise = undefined;
                     };
                     const script = document.createElement('script');
@@ -38,13 +38,14 @@ namespace Provider.Maps.Google.SharedComponents {
                 });
             } 
 
-            // We have to use this listener instead of the callback of the library because the callback will only work of 1st map on the page
+            // We have to use this promise instead of the callback of the library because 
+            // the callback will only work of 1st map on the page
             googleMapsLoadPromise.then(cb);
         }
     }
 
     /**
-     * Remove... balbal
+     * Remove...
      * @param object
      */
     export function RemoveEventsFromProvider(
@@ -58,10 +59,17 @@ namespace Provider.Maps.Google.SharedComponents {
         });
     }
 
-    /** This method will help converting the bounds (string) into the respective coordinates that will be used on the bounds
+    /**
+     * This method will help converting the bounds (string) into the respective coordinates that will be used on the bounds
      * It returns a promise because bounds will get converted into coordinates
      * The method resposible for this conversion (Helper.Conversions.ConvertToCoordinates) also returns a Promise
      * This Promise will only get resolved after the provider gets built (asynchronously)
+     *
+     * @export
+     * @param {OSFramework.Maps.OSStructures.OSMap.BoundsString} bounds
+     * @param {string} apiKey
+     * @param {() => void} errorCb
+     * @return {*}  {Promise<OSFramework.Maps.OSStructures.OSMap.Bounds>}
      */
     export function ConvertStringToBounds(
         bounds: OSFramework.Maps.OSStructures.OSMap.BoundsString,

--- a/src/Providers/Maps/Google/SharedComponents/MapsAndSearchPlaces.ts
+++ b/src/Providers/Maps/Google/SharedComponents/MapsAndSearchPlaces.ts
@@ -27,8 +27,8 @@ namespace Provider.Maps.Google.SharedComponents {
                     script.src = 
                         `${OSFramework.Maps.Helper.Constants.googleMapsApiMap}?` +
                         `key=${apiKey}` +
-                        `&v=${OSFramework.Maps.Helper.Constants.gmversion}` +
                         `&libraries=${OSFramework.Maps.Helper.Constants.gmlibraries}` +
+                        `&v=${OSFramework.Maps.Helper.Constants.gmversion}` +
                         `&loading=async` +
                         `&callback=GMCB`;
                     script.async = true;

--- a/src/Providers/Maps/Leaflet/Marker/Marker.ts
+++ b/src/Providers/Maps/Leaflet/Marker/Marker.ts
@@ -266,6 +266,9 @@ namespace Provider.Maps.Leaflet.Marker {
             if (markerLocation !== undefined) {
                 markerLocation
                     .then((location: L.LatLng) => {
+                        //The marker was destroyed while waiting for the promise.
+                        if(this._destroyed) return;
+                        
                         this._provider = L.marker(location, provider_configs);
                         this._setIcon(this.config.iconUrl);
                         this._setLabelContent(this.config.label);

--- a/src/Providers/Maps/Leaflet/Marker/MarkerPopup.ts
+++ b/src/Providers/Maps/Leaflet/Marker/MarkerPopup.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../../../OSFramework/Maps/Marker/AbstractMarker.ts" />
+/// <reference path="Marker.ts" />
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace Provider.Maps.Leaflet.Marker {

--- a/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
@@ -69,7 +69,7 @@ namespace Provider.Maps.Leaflet.OSMap {
 
         private _setMapEvents(): void {
             // Any events that got added to the mapEvents via the API Subscribe method will have to be taken care here
-            // If the Event type of each handler is MapProviderEvent, we want to make sure to add that event to the listeners of the google maps provider (e.g. click, dblclick, contextmenu, etc)
+            // If the Event type of each handler is MapProviderEvent, we want to make sure to add that event to the listeners of the Google Maps provider (e.g. click, dblclick, contextmenu, etc)
             // Otherwise, we don't want to add them to the google provider listeners (e.g. OnInitialize, OnError, OnTriggeredEvent)
             this.mapEvents.handlers.forEach(
                 (


### PR DESCRIPTION
This PR is in the continuation of previous PR, which introduced some issues, now solved. Additionally more fixes were added.

### What was happening
* When the back button is used, and the previous page has a list records with markers, the markers are first build then destroyed then built again... And when Addresses are passed, what happened was that the FinishBuild was ran after the dispose, causing a glitch in the number of markers per cluster.
* There was a console warning from google: `Google Maps JavaScript API has been loaded directly without loading=async. This can result in suboptimal performance. For best-practice loading patterns please see https://goo.gle/js-api-loading`
* I previous PR, the choice of map center was changed, leading to the marker being always chosen. 

### What was done
* Added the protected attribute `_destroyed` to the `AbstractMarker` class. This attribute will be set to true when the Marker is disposed, so that if the when the `build()` is occurring and the address needs to be converted into coordinates, if the Marker is destroyed meanwhile, upon resolving the address promise, no other code is executed.
* Added the attribute `loading=async` in the URL of Google Maps:
  * Changed the way the callbacks are being invoked, by using a Promise;
  * This caused the warning mentioned above to disappear;
* Added the attribute `v=X.xx` that defines the version of Google Maps to be loaded:
  * Current version being loaded `3.55` will be made stale (or stable) by mid-February 2024;
  * This will enable the Maps to have a stable and controlled version;
* If the map center, is the same as the default, then the map will ignore it. Otherwise, the isAutofit config will be checked, and if false, then the current center will not be changed.
* Small TS fixes
* Small comments changes

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

