### PR TITLE
ROU-4864: Offset and Localization is not being properly treated as an object

### DIFF
--- a/src/OSFramework/Maps/OSMap/AbstractMap.ts
+++ b/src/OSFramework/Maps/OSMap/AbstractMap.ts
@@ -168,9 +168,10 @@ namespace OSFramework.Maps.OSMap {
 		public changeProperty(propertyName: string, propertyValue: unknown): void {
 			//Update Map's config when the property is available
 			if (this.config.hasOwnProperty(propertyName)) {
+				const propName = Maps.Enum.OS_Config_Map[propertyName];
 
-				// Check if is an object to parse the correct value
-				if (typeof this.config[propertyName] === 'object') {
+				// Check if the property value is offset or localization to parse the value
+				if (propName === Maps.Enum.OS_Config_Map.offset || propName === Maps.Enum.OS_Config_Map.localization) {
 					propertyValue = JSON.parse(propertyValue as string);
 				}
 

--- a/src/OSFramework/Maps/OSMap/AbstractMap.ts
+++ b/src/OSFramework/Maps/OSMap/AbstractMap.ts
@@ -168,6 +168,12 @@ namespace OSFramework.Maps.OSMap {
 		public changeProperty(propertyName: string, propertyValue: unknown): void {
 			//Update Map's config when the property is available
 			if (this.config.hasOwnProperty(propertyName)) {
+
+				// Check if is an object to parse the correct value
+				if (typeof this.config[propertyName] === 'object') {
+					propertyValue = JSON.parse(propertyValue as string);
+				}
+
 				this.config[propertyName] = propertyValue;
 
 				if (Maps.Enum.OS_Config_Map.respectUserZoom === Maps.Enum.OS_Config_Map[propertyName]) {


### PR DESCRIPTION
This PR is for fixing an issue when the change property is triggered to update the values on parameters when is an object

### What was happening
* The parameters Offset and Localization are not being properly treated as an object and not properly set to the provider
![image](https://github.com/OutSystems/outsystems-maps/assets/25321845/44833b62-40be-4cf1-b091-57cf8b9212fd)

### What was done
* Added a typeof validation on changeProperty method to check if the propertyName on configs is an Object
![image](https://github.com/OutSystems/outsystems-maps/assets/25321845/0174b0ab-4edb-42ea-a698-626c9ecfaa52)

### Checklist
* [X] tested locally
* [X] documented the code
* [X] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

