### PR TITLE
ROU-4725: [OSMaps] - Leaflet misbehavior when changing marker location after zooming out

### DIFF
--- a/src/OSFramework/Maps/Feature/ICenter.ts
+++ b/src/OSFramework/Maps/Feature/ICenter.ts
@@ -12,7 +12,7 @@ namespace OSFramework.Maps.Feature {
 		/** Refreshes the Current Center position of the Map
 		 * Changes whenever a marker is added or by enabling the Autofit on Zoom feature
 		 */
-		refreshCenter(value: OSFramework.Maps.OSStructures.OSMap.Coordinates): void;
+		refreshCenter(value: OSFramework.Maps.OSStructures.OSMap.Coordinates, allowRefreshZoom?: boolean): void;
 		/** Set Current center position of the Map */
 		setCurrentCenter(value: OSFramework.Maps.OSStructures.OSMap.Coordinates): void;
 		/** Sets or updates the initial center position of the Map.

--- a/src/Providers/Maps/Leaflet/Features/Center.ts
+++ b/src/Providers/Maps/Leaflet/Features/Center.ts
@@ -52,9 +52,27 @@ namespace Provider.Maps.Leaflet.Feature {
 			return responseObj;
 		}
 
-		public refreshCenter(value: OSFramework.Maps.OSStructures.OSMap.Coordinates): void {
+		public refreshCenter(value: OSFramework.Maps.OSStructures.OSMap.Coordinates, allowRefreshZoom: boolean): void {
 			const coordinates = new L.LatLng(value.lat as number, value.lng as number);
 			this._map.provider.setView(coordinates);
+			if (allowRefreshZoom) {
+				if (this._map.features.zoom.isAutofit) {
+					if (
+						this._map.markers.length > 1 ||
+						(this._map.shapes.length > 0 && this._map.config.autoZoomOnShapes === true)
+					) {
+						this._map.provider.setView(coordinates);
+						this._map.features.zoom.refreshZoom();
+					} else {
+						this._map.provider.setView(coordinates, OSFramework.Maps.Helper.Constants.zoomAutofit);
+					}
+				} else {
+					this._map.provider.setView(coordinates, this._map.features.zoom.level);
+				}
+			} else {
+				this._map.provider.setView(coordinates);
+			}
+
 			this._currentCenter = coordinates;
 		}
 

--- a/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
@@ -290,13 +290,8 @@ namespace Provider.Maps.Leaflet.OSMap {
 				}
 			}
 
-			// Refresh the center position
-			this.features.center.refreshCenter(position);
-
-			if (this.allowRefreshZoom) {
-				// Refresh the zoom
-				this.features.zoom.refreshZoom();
-			}
+			// Refresh the center position and zoom if needed
+			this.features.center.refreshCenter(position, this.allowRefreshZoom);
 
 			// Refresh the offset
 			this.features.offset.setOffset(this.features.offset.getOffset);


### PR DESCRIPTION
This PR is for fixing an issue that occurs when changing the location of a marker (with more also occurs), after zooming out.

### What was happening
* Misbehavior when changing marker location after zooming out

### What was done
* Change leaflet refresh method to apply the zoom in the same method where the center is applied;

### Test Steps
1.  Go to page do a zoom 
2. Change the Center/Marker position
3. Check if it pans as expected

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

