### PR TITLE
ROU-10780: fix Google Maps custom markers with scaled sizes

### DIFF
--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -25,8 +25,9 @@ namespace Provider.Maps.Google.Marker {
 				this.provider.setIcon(null);
 			} else {
 				try {
+					let anchorCalc: google.maps.Point;
 					let scaledSize: google.maps.Size;
-					//Explicit conversion to number - related with ROU-4592 - as google will behave differently depending on the type
+					//Explicit conversion to number - related with ROU-4592 - as Google will behave differently depending on the type
 					//of the input. Before, in runtime, the input was of type string.
 					const height = Number(this.config.iconHeight);
 					const width = Number(this.config.iconWidth);
@@ -38,12 +39,16 @@ namespace Provider.Maps.Google.Marker {
 						height > 0 &&
 						width > 0
 					) {
+						// Anchor at bottom center (half width, full height)
+						anchorCalc = new google.maps.Point(width / 2, height);
 						scaledSize = new google.maps.Size(width, height);
 					}
 					// Update the icon using the previous configurations
 					const icon = {
 						url: url,
-						size: scaledSize,
+						scaledSize: scaledSize,
+						anchor: anchorCalc,
+						origin: new google.maps.Point(0, 0),
 					};
 					// Set the icon to the Marker provider
 					this.provider.setIcon(icon);


### PR DESCRIPTION
This PR is to fix Google Maps custom markers with scaled sizes.

### What was happening
* Setting custom markers using URL and icon size being set, didn’t have the right behaviour (regression from v1.6.6) and the markers didn't appear properly:

![Issue_MapsMarker](https://github.com/OutSystems/outsystems-maps/assets/29493222/da585011-4ede-4dd4-98d2-1aca1f0a5c81)


### What was done
* The Google Maps marker API on the OutSystems MAps implementation used in the method `_setIcon` is an object with an attribute `size` when it should use `scaledSize`.
* Also, the Google Maps API got changed and requires the attributes `anchor` and, for readability (not mandatory in this case), also the `origin` so the icon gets properly scaled. 

### Test Steps
1. Create a test screen with two Maps using custom markers - one setting up the IconSize and the other without this structure filled in
2. Check that for both Maps we can properly see the Markers we just defined on the low code implementation


### Screenshots
![image](https://github.com/OutSystems/outsystems-maps/assets/29493222/ea275180-3f5e-4960-a5ea-19d3694ada21)



### Checklist
* [X] tested locally
* [X] documented the code
* [X] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

