### PR TITLE
ROU-10685 - [OSMaps] - Leaflet misbehavior when changing marker location after zooming out with more than 2 markers

### DIFF
--- a/src/Providers/Maps/Leaflet/Features/Zoom.ts
+++ b/src/Providers/Maps/Leaflet/Features/Zoom.ts
@@ -33,7 +33,7 @@ namespace Provider.Maps.Leaflet.Feature {
 			}
 			this._map.provider.fitBounds(bounds);
 			this._map.provider.panInsideBounds(bounds);
-			this._map.features.center.setCurrentCenter(this._map.provider.getCenter());
+			this._map.features.center.setCurrentCenter(bounds.getCenter());
 		}
 
 		public build(): void {
@@ -56,7 +56,10 @@ namespace Provider.Maps.Leaflet.Feature {
 				) {
 					this._setBounds(this._map.config.autoZoomOnShapes);
 				} else {
-					this._map.provider.setZoom(OSFramework.Maps.Helper.Constants.zoomAutofit);
+					this._map.provider.setView(
+						this._map.features.center.getCurrentCenter() as L.LatLngExpression,
+						OSFramework.Maps.Helper.Constants.zoomAutofit
+					);
 				}
 			} else {
 				this._map.provider.setZoom(this._map.features.zoom.level);


### PR DESCRIPTION
This PR is for fixing the pan/zoom on the leaflet map when reacting to the markers update.

### What was happening
* When markers were added or deleted on the leaflet map, the autofit behavior was not happening as supposed

### What was done
* Use SetView on refreshZoom to guarantee the center is the latest;

### Test Steps
1. Go to the Sample
2. Add various icons and delete some of them
3. Check if the map reacts as expected
4. Toggle the "Respect user zoom"
5. Interact again with the markers and do some zooms
6. Check if the map reacts as expected


### Screenshots
![LeafletMarkers_reacting](https://github.com/OutSystems/outsystems-maps/assets/60441552/6e90cce4-794a-4094-aa04-ab749eec62de)


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

