### PR TITLE
ROU-10685_V2 - [OSMaps] - Leaflet misbehavior when changing marker location after zooming out with more than 2 markers

### DIFF
--- a/src/Providers/Maps/Leaflet/Features/Center.ts
+++ b/src/Providers/Maps/Leaflet/Features/Center.ts
@@ -53,7 +53,7 @@ namespace Provider.Maps.Leaflet.Feature {
 		}
 
 		public refreshCenter(value: OSFramework.Maps.OSStructures.OSMap.Coordinates, allowRefreshZoom: boolean): void {
-			const coordinates = new L.LatLng(value.lat as number, value.lng as number);
+			let coordinates = new L.LatLng(value.lat as number, value.lng as number);
 			this._map.provider.setView(coordinates);
 			if (allowRefreshZoom) {
 				if (this._map.features.zoom.isAutofit) {
@@ -63,6 +63,8 @@ namespace Provider.Maps.Leaflet.Feature {
 					) {
 						this._map.provider.setView(coordinates);
 						this._map.features.zoom.refreshZoom();
+						const tempCenter = this._map.features.center.getCurrentCenter();
+						coordinates = new L.LatLng(tempCenter.lat as number, tempCenter.lng as number);
 					} else {
 						this._map.provider.setView(coordinates, OSFramework.Maps.Helper.Constants.zoomAutofit);
 					}


### PR DESCRIPTION
### What was done
* Make sure the current center is updated with the right coordinates, when they are calculated by the bounds.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

