### PR TITLE
ROU-11371: [OSMaps] - Leaflet center not working as expected

### DIFF
--- a/src/OSFramework/Maps/OSMap/IMap.ts
+++ b/src/OSFramework/Maps/OSMap/IMap.ts
@@ -157,8 +157,9 @@ namespace OSFramework.Maps.OSMap {
 		/**
 		 * Refreshes the Map after changing zoom or center.
 		 * Can be used to reset to the defined zoom, center and offset configurations.
+		 * @param {boolean} [centerchanged]
 		 */
-		refresh(): void;
+		refresh(centerchanged?: boolean): void;
 		/**
 		 * Refreshes the Events of the Map Provider after Subscribing/Unsubscribing events
 		 */

--- a/src/Providers/Maps/Google/Features/Center.ts
+++ b/src/Providers/Maps/Google/Features/Center.ts
@@ -67,7 +67,7 @@ namespace Provider.Maps.Google.Feature {
 				.then((response) => {
 					this._map.config.center = response;
 					this._initialCenter = response;
-					this._map.refresh();
+					this._map.refresh(true);
 				})
 				.catch((error) => {
 					this._map.mapEvents.trigger(

--- a/src/Providers/Maps/Google/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Google/OSMap/OSMap.ts
@@ -426,7 +426,7 @@ namespace Provider.Maps.Google.OSMap {
 			this._provider = undefined;
 		}
 
-		public refresh(): void {
+		public refresh(centerChanged?: boolean): void {
 			//Let's stop listening to the zoom event be caused by the refreshZoom
 			this._removeMapZoomHandler();
 
@@ -439,12 +439,14 @@ namespace Provider.Maps.Google.OSMap {
 			//If there are markers, let's choose the map center accordingly.
 			//Otherwise, the map center will be the one defined in the configs.
 			if (this.markers.length > 0) {
+				// The TS definitions appear to be outdated.
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const markerProvider: any = this.markers[0].provider;
 				if (this.markers.length > 1) {
 					//As the map has more than one marker, let's see if the map
 					//center should be changed.
 					//If the user hasn't change zoom, or the developer is ignoring it (current behavior).
 					if (this.allowRefreshZoom) {
-						const markerProvider = this.markers[0].provider;
 						//Let's check if the marker provider is ready to be used.
 						if (markerProvider !== undefined) {
 							//If the map center, is the same as the default, then the map will ignore it.
@@ -452,22 +454,20 @@ namespace Provider.Maps.Google.OSMap {
 							//center will not be changed.
 							if (isDefault || this.features.zoom.isAutofit) {
 								//Let's use the first marker as the center of the map.
-								// The TS definitions appear to be outdated.
-								// eslint-disable-next-line @typescript-eslint/no-explicit-any
-								position = (markerProvider as any).position.toJSON();
+								position = markerProvider.position.toJSON();
 							}
 						}
 					} else {
 						//If the user has zoomed and the developer intends to respect user zoom
 						//then the current map center will be used.
-						position = this.provider.getCenter().toJSON();
+						position = centerChanged
+							? (this.config.center as OSFramework.Maps.OSStructures.OSMap.Coordinates)
+							: this.provider.getCenter().toJSON();
 					}
-				} else if (this.markers[0].provider !== undefined) {
+				} else if (markerProvider !== undefined) {
 					//If there's only one marker, and is already created, its location will be
 					//used as the map center.
-					// The TS definitions appear to be outdated.
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					position = (this.markers[0].provider as any).position.toJSON();
+					position = markerProvider.position.toJSON();
 				}
 			}
 

--- a/src/Providers/Maps/Leaflet/Features/Center.ts
+++ b/src/Providers/Maps/Leaflet/Features/Center.ts
@@ -87,7 +87,7 @@ namespace Provider.Maps.Leaflet.Feature {
 				.then((response) => {
 					this._map.config.center = response;
 					this._initialCenter = response;
-					this._map.refresh();
+					this._map.refresh(true);
 				})
 				.catch(() => {
 					this._map.mapEvents.trigger(

--- a/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Leaflet/OSMap/OSMap.ts
@@ -260,7 +260,7 @@ namespace Provider.Maps.Leaflet.OSMap {
 			this._provider = undefined;
 		}
 
-		public refresh(): void {
+		public refresh(centerChanged?: boolean): void {
 			//Let's stop listening to the zoom event be caused by the refreshZoom
 			this._removeMapZoomHandler();
 
@@ -277,11 +277,15 @@ namespace Provider.Maps.Leaflet.OSMap {
 						//If the user hasn't change zoom, or the developer is ignoring
 						//it (current behavior), then the map will be centered tentatively
 						//in the first marker.
-						position = markerProvider.getLatLng();
+						if (this.features.zoom.isAutofit) {
+							position = markerProvider.getLatLng();
+						}
 					} else {
 						//If the user has zoomed and the developer intends to respect user zoom
 						//then the current map center will be used.
-						position = this.provider.getCenter();
+						position = centerChanged
+							? (this.config.center as OSFramework.Maps.OSStructures.OSMap.Coordinates)
+							: this.provider.getCenter();
 					}
 				} else if (markerProvider !== undefined) {
 					//If there's only one marker, and is already created, its location will be


### PR DESCRIPTION
This PR is for fixing the center update when the map was panned or zoomed, and the markers were presented.

### What was happening
* The center parameter was not respected when the user used the leaflet map with markers.

### What was done
* add a flag to refresh the center position if the user changes the center;
* Clean and normalize refresh function on both providers;

### Test Steps
1. Go to the sample page, and use the different buttons to change the center; 
2. Interact with both maps and afterward with the buttons;
3. Check if the maps behave as expected;

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

