### PR TITLE
ROU-11587_V2: javaScript Causing Error Logs on Google Places

### DIFF
--- a/src/OSFramework/Maps/SearchPlaces/AbstractSearchPlaces.ts
+++ b/src/OSFramework/Maps/SearchPlaces/AbstractSearchPlaces.ts
@@ -80,6 +80,7 @@ namespace OSFramework.Maps.SearchPlaces {
 
 		public dispose(): void {
 			this._built = false;
+			this._uniqueId = undefined;
 		}
 
 		public equalsToID(id: string): boolean {

--- a/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
@@ -78,24 +78,27 @@ namespace Provider.Maps.Google.SearchPlaces {
 		}
 
 		private _createProvider(configs: Configuration.SearchPlaces.ISearchPlacesProviderConfig): void {
-			const input: HTMLInputElement = OSFramework.Maps.Helper.GetElementByUniqueId(this.uniqueId).querySelector(
-				`${OSFramework.Maps.Helper.Constants.runtimeSearchPlacesUniqueIdCss} input`
-			);
-			if (this._validInput(input) === false) return;
+			// This is to guarantee that the widget was not disposed before reaching this method
+			if (this.uniqueId !== undefined) {
+				const input: HTMLInputElement = OSFramework.Maps.Helper.GetElementByUniqueId(
+					this.uniqueId
+				).querySelector(`${OSFramework.Maps.Helper.Constants.runtimeSearchPlacesUniqueIdCss} input`);
+				if (this._validInput(input) === false) return;
 
-			// SearchPlaces(input, options)
-			this._provider = new google.maps.places.Autocomplete(input, configs as unknown);
-			// Check if the provider has been created with a valid APIKey
-			window[Constants.googleMapsAuthFailure] = () => {
-				this.searchPlacesEvents.trigger(
-					OSFramework.Maps.Event.SearchPlaces.SearchPlacesEventType.OnError,
-					this,
-					OSFramework.Maps.Enum.ErrorCodes.LIB_InvalidApiKeySearchPlaces
-				);
-			};
+				// SearchPlaces(input, options)
+				this._provider = new google.maps.places.Autocomplete(input, configs as unknown);
+				// Check if the provider has been created with a valid APIKey
+				window[Constants.googleMapsAuthFailure] = () => {
+					this.searchPlacesEvents.trigger(
+						OSFramework.Maps.Event.SearchPlaces.SearchPlacesEventType.OnError,
+						this,
+						OSFramework.Maps.Enum.ErrorCodes.LIB_InvalidApiKeySearchPlaces
+					);
+				};
 
-			this.finishBuild();
-			this._setSearchPlacesEvents();
+				this.finishBuild();
+				this._setSearchPlacesEvents();
+			}
 		}
 
 		/**


### PR DESCRIPTION
This PR is for improve the google.places creation, by checking if config.uniqueId still exists before create provider.

### What was done
* Validate the uniqueId saved in configs was not clean before reaching createProvider();

### Test Steps
1. Go to sample
2. Destroy and Create places repeatedly when the page is rendering;
3. Check that there are no errors in console related with places uniqueId;
 
### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

