### PR TITLE
ROU-11629: javaScript Causing Error Logs on Google Maps

### DIFF
--- a/src/OSFramework/Maps/SearchPlaces/AbstractSearchPlaces.ts
+++ b/src/OSFramework/Maps/SearchPlaces/AbstractSearchPlaces.ts
@@ -80,7 +80,6 @@ namespace OSFramework.Maps.SearchPlaces {
 
 		public dispose(): void {
 			this._built = false;
-			this._uniqueId = undefined;
 		}
 
 		public equalsToID(id: string): boolean {

--- a/src/Providers/Maps/Google/OSMap/OSMap.ts
+++ b/src/Providers/Maps/Google/OSMap/OSMap.ts
@@ -84,44 +84,46 @@ namespace Provider.Maps.Google.OSMap {
 				// Make sure the center is saved before setting a default value which is going to be used
 				// before the conversion of the location to coordinates gets resolved
 				const currentCenter = this.config.center;
+				// This is to guarantee that the widget was not disposed before reaching this method
+				const mapElement = OSFramework.Maps.Helper.GetElementByUniqueId(this.uniqueId, false);
 
-				this._provider = new google.maps.Map(
-					OSFramework.Maps.Helper.GetElementByUniqueId(this.uniqueId).querySelector(
-						OSFramework.Maps.Helper.Constants.runtimeMapUniqueIdCss
-					),
-					// The provider config will retrieve the default center position
-					// (this.config.center = OSFramework.Maps.Helper.Constants.defaultMapCenter)
-					// Which will get updated after the Map is rendered
-					this._getProviderConfig()
-				);
-				// Check if the provider has been created with a valid APIKey
-				window[Constants.googleMapsAuthFailure] = () =>
-					this.mapEvents.trigger(
-						OSFramework.Maps.Event.OSMap.MapEventType.OnError,
-						this,
-						OSFramework.Maps.Enum.ErrorCodes.LIB_InvalidApiKeyMap
+				if (mapElement !== undefined) {
+					this._provider = new google.maps.Map(
+						mapElement.querySelector(OSFramework.Maps.Helper.Constants.runtimeMapUniqueIdCss),
+						// The provider config will retrieve the default center position
+						// (this.config.center = OSFramework.Maps.Helper.Constants.defaultMapCenter)
+						// Which will get updated after the Map is rendered
+						this._getProviderConfig()
 					);
+					// Check if the provider has been created with a valid APIKey
+					window[Constants.googleMapsAuthFailure] = () =>
+						this.mapEvents.trigger(
+							OSFramework.Maps.Event.OSMap.MapEventType.OnError,
+							this,
+							OSFramework.Maps.Enum.ErrorCodes.LIB_InvalidApiKeyMap
+						);
 
-				this.buildFeatures();
-				this._buildMarkers();
-				this._buildShapes();
-				this._buildDrawingTools();
-				this._buildFileLayers();
-				this._buildHeatmapLayers();
-				this.finishBuild();
+					this.buildFeatures();
+					this._buildMarkers();
+					this._buildShapes();
+					this._buildDrawingTools();
+					this._buildFileLayers();
+					this._buildHeatmapLayers();
+					this.finishBuild();
 
-				// Make sure to change the center after the conversion of the location to coordinates
-				this.features.center.updateCenter(currentCenter as string);
+					// Make sure to change the center after the conversion of the location to coordinates
+					this.features.center.updateCenter(currentCenter as string);
 
-				// Make sure the style is converted from an id to the correspondent JSON
-				this._provider.setOptions({
-					styles: GetStyleByStyleId(this.config.style),
-					...this._advancedFormatObj,
-				});
+					// Make sure the style is converted from an id to the correspondent JSON
+					this._provider.setOptions({
+						styles: GetStyleByStyleId(this.config.style),
+						...this._advancedFormatObj,
+					});
 
-				// We can only set the events on the provider after its creation
-				this._setMapEvents(this._advancedFormatObj.mapEvents);
-				this._addMapZoomHandler();
+					// We can only set the events on the provider after its creation
+					this._setMapEvents(this._advancedFormatObj.mapEvents);
+					this._addMapZoomHandler();
+				}
 			} else {
 				throw Error(`The google.maps lib has not been loaded.`);
 			}

--- a/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
@@ -79,10 +79,12 @@ namespace Provider.Maps.Google.SearchPlaces {
 
 		private _createProvider(configs: Configuration.SearchPlaces.ISearchPlacesProviderConfig): void {
 			// This is to guarantee that the widget was not disposed before reaching this method
-			if (this.uniqueId !== undefined) {
-				const input: HTMLInputElement = OSFramework.Maps.Helper.GetElementByUniqueId(
-					this.uniqueId
-				).querySelector(`${OSFramework.Maps.Helper.Constants.runtimeSearchPlacesUniqueIdCss} input`);
+			const placesElement = OSFramework.Maps.Helper.GetElementByUniqueId(this.uniqueId, false);
+
+			if (placesElement !== undefined) {
+				const input: HTMLInputElement = placesElement.querySelector(
+					`${OSFramework.Maps.Helper.Constants.runtimeSearchPlacesUniqueIdCss} input`
+				);
 				if (this._validInput(input) === false) return;
 
 				// SearchPlaces(input, options)


### PR DESCRIPTION
This PR is for fixing javascript error logs.

### What was happening
* When we destroyed the maps element before they finished the building process, was possible to reach an error, on the provider creation 

### What was done
* Guarantee the mapElement exists when creating the provider;
* Simplify this validation on Google Places creation;

### Test Steps
1. While the page is rendering, switch Show and Hide repeatedly 
2. Check the console if there are any errors


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

