### PR TITLE
ROU-11589: Making sure parameters are of the right type

### DIFF
--- a/src/Providers/Maps/Leaflet/Configuration/Marker/LeafletMarkerConfig.ts
+++ b/src/Providers/Maps/Leaflet/Configuration/Marker/LeafletMarkerConfig.ts
@@ -14,6 +14,13 @@ namespace Provider.Maps.Leaflet.Configuration.Marker {
 		public location: string;
 		public title?: string;
 
+		constructor(config: unknown) {
+			super(config);
+			//making sure that the iconHeight and iconWidth are numbers
+			this.iconHeight = Number(this.iconHeight);
+			this.iconWidth = Number(this.iconWidth);
+		}
+
 		public getProviderConfig(): L.MarkerOptions {
 			const provider: L.MarkerOptions = {
 				draggable: this.allowDrag,


### PR DESCRIPTION
This PR is for fixing the input parameter type for the icon width and height.

### What was happening
* When using a marker with an icon, and passing the dimentions
* The units were being passed wrongly to the provider (in string instead of number):
![image](https://github.com/user-attachments/assets/77ddcdc0-e7f6-42a9-a15a-72a15e7e2908)
* This cause the observed misbehave:
![map-icon-misbehave](https://github.com/user-attachments/assets/62f47051-96fd-41aa-81a1-15c6d5de54ec)

### What was done
* Upon constructing the object `LeafletMarkerConfig`, the configs will now be forced to the right type:
![image](https://github.com/user-attachments/assets/1384adba-7d2e-4df4-828b-5f1141889d3d)
* This corrected the misbehave:
![map-icon-good](https://github.com/user-attachments/assets/66592adc-b16a-4b3e-a248-5d312739d548)

### Test Steps
1. Use the leaflet map
2. Add a marker
3. Add an icon url to the marker
4. Pass the width and height
5. Publish
6. Click on the marker
7. (The map should not change the center)


### Screenshots
(prefer animated gif)


### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

