### PR TITLE
ROU-11492: Fix access to secrets

### DIFF
--- a/.github/os-git-actions/get-azure-secret/action.yml
+++ b/.github/os-git-actions/get-azure-secret/action.yml
@@ -1,0 +1,46 @@
+name: 'get-azure-secret'
+description: 'Gets a secret from a given Azure Key Vault'
+inputs:
+    client-id:
+        description: 'The input parameter client-id specifies the login client id. It could be the client id of a service principal or a user-assigned managed identity.'
+        required: true
+        default: ''
+    tenant-id:
+        description: 'The input parameter tenant-id specifies the login tenant id.'
+        required: true
+        default: ''
+    subscription-id:
+        description: 'The input parameter subscription-id specifies the login subscription id.'
+        required: false
+        default: false
+    vault-name:
+        description: 'The input parameter vault-name specifies the name of the key vault.'
+        required: true
+        default: ''
+    key-name:
+        description: 'The input parameter key-name specifies the name of the key to get the secret from.'
+        required: false
+        default: ''
+outputs:
+    OBTAINED_SECRET:
+        description: 'The output parameter OBTAINED_SECRET specifies the secret value.'
+        value: ${{ steps.GetSecret.outputs.az-obtained-secret }}
+
+runs:
+    using: composite
+    steps:
+        - name: 'Az CLI login'
+          uses: azure/login@v2
+          with:
+              client-id: ${{ inputs.client-id }}
+              tenant-id: ${{ inputs.tenant-id }}
+              subscription-id: ${{ inputs.subscription-id }}
+
+        - name: get keyvault secrets
+          uses: azure/cli@v2
+          id: GetSecret
+          with:
+              inlineScript: |
+                  secretValue=$(az keyvault secret show --name "${{ inputs.key-name }}" --vault-name "${{ inputs.vault-name }}" --query "value" --output tsv)
+                  echo "::add-mask::$secretValue"
+                  echo "az-obtained-secret=$secretValue" >> $GITHUB_OUTPUT

--- a/.github/os-git-actions/get-azure-secret/action.yml
+++ b/.github/os-git-actions/get-azure-secret/action.yml
@@ -30,14 +30,14 @@ runs:
     using: composite
     steps:
         - name: 'Az CLI login'
-          uses: azure/login@v2
+          uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
           with:
               client-id: ${{ inputs.client-id }}
               tenant-id: ${{ inputs.tenant-id }}
               subscription-id: ${{ inputs.subscription-id }}
 
         - name: get keyvault secrets
-          uses: azure/cli@v2
+          uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
           id: GetSecret
           with:
               inlineScript: |

--- a/.github/os-git-actions/setup-gpg/action.yml
+++ b/.github/os-git-actions/setup-gpg/action.yml
@@ -1,13 +1,23 @@
 name: 'setup-gpg'
 description: 'Prepare to get following commits signed'
 
+inputs:
+    gpgPriv:
+        description: 'GPG Private key'
+        required: true
+        default: ''
+    gpgPassPhrase:
+        description: 'GPG passphrase'
+        required: false
+        default: '""'
+
 runs:
     using: composite
     steps:
         - name: Import and load GPG key
           uses: crazy-max/ghaction-import-gpg@v6
           with:
-              gpg_private_key: ${{ secrets.GPG_SIGN_KEY }}
-              passphrase: ${{ secrets.GPG_PASSPHRASE }}
+              gpg_private_key: ${{ inputs.gpgPriv }}
+              passphrase: ${{ inputs.gpgPassPhrase }}
               git_user_signingkey: true
               git_commit_gpgsign: true

--- a/.github/os-git-actions/setup-gpg/action.yml
+++ b/.github/os-git-actions/setup-gpg/action.yml
@@ -15,7 +15,7 @@ runs:
     using: composite
     steps:
         - name: Import and load GPG key
-          uses: crazy-max/ghaction-import-gpg@v6
+          uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
           with:
               gpg_private_key: ${{ inputs.gpgPriv }}
               passphrase: ${{ inputs.gpgPassPhrase }}

--- a/.github/os-git-actions/signed-commit/action.yml
+++ b/.github/os-git-actions/signed-commit/action.yml
@@ -13,12 +13,23 @@ inputs:
         description: 'Defines if a `git add.` should be made or not.'
         required: false
         default: false
+    gpgPriv:
+        description: 'GPG Private key'
+        required: true
+        default: ''
+    gpgPassPhrase:
+        description: 'GPG passphrase'
+        required: false
+        default: '""'
 
 runs:
     using: composite
     steps:
         - name: Setup GPG to sign commits
           uses: ./.github/os-git-actions/setup-gpg/
+          with:
+              gpgPriv: ${{ inputs.gpgPriv }}
+              gpgPassPhrase: ${{ inputs.gpgPassPhrase }}
 
         - name: Perform git commit
           uses: ./.github/os-git-actions/manual-commit/

--- a/.github/workflows/DevPR.yml
+++ b/.github/workflows/DevPR.yml
@@ -12,7 +12,7 @@ jobs:
                 working-directory: ./
         steps:
             - name: Checkout branch dev
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Install project dependencies
               run: npm install
@@ -25,7 +25,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout branch dev
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Install project dependencies
               run: npm install

--- a/.github/workflows/PreRelease.yml
+++ b/.github/workflows/PreRelease.yml
@@ -119,3 +119,5 @@ jobs:
                   branch: dev
                   message: 'Updated into v${{ inputs.new-dev-release }} [skip ci]'
                   newFiles: true
+                  gpgPriv: ${{ secrets.GPG_SIGN_KEY }}
+                  gpgPassPhrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/PreRelease.yml
+++ b/.github/workflows/PreRelease.yml
@@ -23,7 +23,7 @@ jobs:
         if: ${{ inputs.new-version }}
         steps:
             - name: Checkout into dev
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   ref: dev
                   token: ${{ secrets.PAT }}
@@ -41,7 +41,7 @@ jobs:
         if: ${{ inputs.new-version }}
         steps:
             - name: Checkout into dev
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   ref: dev
                   token: ${{ secrets.PAT }}
@@ -58,7 +58,7 @@ jobs:
         if: ${{ inputs.new-version }}
         steps:
             - name: Checkout into rc${{ inputs.new-version }}
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   ref: rc${{ inputs.new-version }}
                   fetch-depth: 0
@@ -77,7 +77,7 @@ jobs:
         steps:
             - name: Create Release
               id: create_release
-              uses: softprops/action-gh-release@v2.0.5
+              uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
               with:
                   tag_name: v${{ inputs.new-version }}
                   name: Release of version ${{ inputs.new-version }} (${{ inputs.release-date }})
@@ -101,7 +101,7 @@ jobs:
         if: ${{ inputs.new-version && inputs.new-dev-release }}
         steps:
             - name: Checkout into dev
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   ref: dev
                   token: ${{ secrets.PAT }}

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -23,7 +23,7 @@ jobs:
         if: ${{ inputs.new-version }}
         steps:
             - name: Checkout into rc${{ inputs.new-version }}
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   ref: rc${{ inputs.new-version }}
                   token: ${{ secrets.PAT }}
@@ -68,7 +68,7 @@ jobs:
         if: ${{ inputs.delete-rc-branch == true }}
         steps:
             - name: Checkout branch dev
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   ref: dev
 


### PR DESCRIPTION
This PR is for fixing the access to the github secrets.

### What was happening
* Due to a misunderstanding the place where the repo secrets were being accessed from, they were not available.

### What was done
* Created input parameters in the git actions
* The workflow accesses and passes the secrets as input values

### Impact
* These changes *only* affects the workflow used for the creation of new Pre-Releases

### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)