### PR TITLE
ROU-12041: Adapting to block name change

### DIFF
--- a/src/OSFramework/Maps/Helper/Constants.ts
+++ b/src/OSFramework/Maps/Helper/Constants.ts
@@ -28,6 +28,7 @@ namespace OSFramework.Maps.Helper.Constants {
 	export const heatmapLayerTag = '[data-block="HeatmapLayer.HeatmapLayer"]';
 	/** Tag used to find the SearchPlaces */
 	export const searchPlacesTag = '[data-block="SearchPlaces.SearchPlaces"]';
+	export const searchPlacesTag_Legacy = '[data-block="SearchPlacesLegacy.SearchPlaces_Legacy"]';
 
 	/** Tag used to find a generic widget */
 	export const outsystemsWidgetTag = '[data-block]';

--- a/src/OSFramework/Maps/SearchPlaces/AbstractSearchPlaces.ts
+++ b/src/OSFramework/Maps/SearchPlaces/AbstractSearchPlaces.ts
@@ -11,6 +11,7 @@ namespace OSFramework.Maps.SearchPlaces {
 
 		protected _built: boolean;
 		protected _provider: W;
+		protected abstract readonly _searchPlacesTag: string;
 
 		public abstract addedEvents: Array<string>;
 
@@ -46,7 +47,7 @@ namespace OSFramework.Maps.SearchPlaces {
 
 		private _setWidgetId(): void {
 			this._widgetId = Helper.GetElementByUniqueId(this.uniqueId, false)
-				? Helper.GetElementByUniqueId(this.uniqueId).closest(Helper.Constants.searchPlacesTag).id
+				? Helper.GetElementByUniqueId(this.uniqueId).closest(this._searchPlacesTag).id
 				: undefined;
 		}
 

--- a/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
@@ -6,7 +6,7 @@ namespace Provider.Maps.Google.SearchPlaces {
 		google.maps.places.PlaceAutocompleteElement,
 		OSFramework.Maps.Configuration.IConfigurationSearchPlaces
 	> {
-		private readonly _addedEvents: Array<string>;
+		private _addedEvents: Array<string>;
 		private _scriptCallback: OSFramework.Maps.Callbacks.Generic;
 		protected readonly _searchPlacesTag = OSFramework.Maps.Helper.Constants.searchPlacesTag;
 
@@ -284,7 +284,7 @@ namespace Provider.Maps.Google.SearchPlaces {
 		public dispose(): void {
 			this._provider = undefined;
 			this._scriptCallback = undefined;
-			this._addedEvents.length = 0; // Clear the addedEvents array
+			this._addedEvents = undefined;
 			super.dispose();
 		}
 	}

--- a/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/SearchPlaces.ts
@@ -8,6 +8,7 @@ namespace Provider.Maps.Google.SearchPlaces {
 	> {
 		private readonly _addedEvents: Array<string>;
 		private _scriptCallback: OSFramework.Maps.Callbacks.Generic;
+		protected readonly _searchPlacesTag = OSFramework.Maps.Helper.Constants.searchPlacesTag;
 
 		constructor(searchPlacesId: string, configs: JSON) {
 			super(searchPlacesId, new Configuration.SearchPlaces.SearchPlacesConfig(configs));

--- a/src/Providers/Maps/Google/SearchPlaces/SearchPlacesLegacy.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/SearchPlacesLegacy.ts
@@ -293,6 +293,8 @@ namespace Provider.Maps.Google.SearchPlaces {
 
 		public dispose(): void {
 			this._provider = undefined;
+			this._scriptCallback = undefined;
+			this._addedEvents = undefined;
 			super.dispose();
 		}
 	}

--- a/src/Providers/Maps/Google/SearchPlaces/SearchPlacesLegacy.ts
+++ b/src/Providers/Maps/Google/SearchPlaces/SearchPlacesLegacy.ts
@@ -8,6 +8,7 @@ namespace Provider.Maps.Google.SearchPlaces {
 	> {
 		private _addedEvents: Array<string>;
 		private _scriptCallback: OSFramework.Maps.Callbacks.Generic;
+		protected readonly _searchPlacesTag = OSFramework.Maps.Helper.Constants.searchPlacesTag_Legacy;
 
 		constructor(searchPlacesId: string, configs: JSON) {
 			super(searchPlacesId, new Configuration.SearchPlaces.SearchPlacesLegacyConfig(configs));


### PR DESCRIPTION
This PR is for adapt the code to the block name change. Small improvements

### What was happening
* The SearchPlaces block name was changed, and this caused a runtime error.

### What was done
* Added a new constant with the legacy block name
* Cleaned objects in these classes

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

