### PR TITLE
ROU-12041: Changing the name of the block

### DIFF
--- a/src/OSFramework/Maps/Helper/Constants.ts
+++ b/src/OSFramework/Maps/Helper/Constants.ts
@@ -28,7 +28,7 @@ namespace OSFramework.Maps.Helper.Constants {
 	export const heatmapLayerTag = '[data-block="HeatmapLayer.HeatmapLayer"]';
 	/** Tag used to find the SearchPlaces */
 	export const searchPlacesTag = '[data-block="SearchPlaces.SearchPlaces"]';
-	export const searchPlacesTag_Legacy = '[data-block="SearchPlacesLegacy.SearchPlaces_Legacy"]';
+	export const searchPlacesTag_Legacy = '[data-block="SearchPlaces_Legacy.SearchPlaces_Legacy"]';
 
 	/** Tag used to find a generic widget */
 	export const outsystemsWidgetTag = '[data-block]';


### PR DESCRIPTION
This PR is for updating the SearchPlaces Legacy block attribute name. This reflects the latest changes in the name.