### PR TITLE
ROU-12040: Handling promise error when no route is found

### DIFF
--- a/src/OutSystems/Maps/MapAPI/Directions.ts
+++ b/src/OutSystems/Maps/MapAPI/Directions.ts
@@ -53,7 +53,14 @@ namespace OutSystems.Maps.MapAPI.Directions {
 	export async function SetDirections(mapId: string, options: string): Promise<string> {
 		const map = MapManager.GetMapById(mapId, true);
 		const directionOptions = JSON.parse(options);
-		return map.features.directions.setRoute(directionOptions).then((response) => JSON.stringify(response));
+		return map.features.directions
+			.setRoute(directionOptions)
+			.then((result) => {
+				return JSON.stringify(result);
+			})
+			.catch((error) => {
+				return JSON.stringify(error);
+			});
 	}
 
 	/**


### PR DESCRIPTION
This PR is for fixing the promise that was not handling when it was rejected. This cause the error message not to be propagated to Low-Code.