### PR TITLE
ROU-12069: Fix error that occured when the map was destroyed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,7 +29,7 @@
 		"editor.defaultFormatter": "vscode.json-language-features"
 	},
 	"sonarlint.connectedMode.project": {
-		"connectionId": "outsystemsrd",
+		"connectionId": "outsystems",
 		"projectKey": "OutSystems_outsystems-maps"
 	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,7 +29,7 @@
 		"editor.defaultFormatter": "vscode.json-language-features"
 	},
 	"sonarlint.connectedMode.project": {
-		"connectionId": "outsystems",
+		"connectionId": "outsystemsrd",
 		"projectKey": "OutSystems_outsystems-maps"
 	}
 }

--- a/src/OutSystems/Maps/MapAPI/MapManager.ts
+++ b/src/OutSystems/Maps/MapAPI/MapManager.ts
@@ -157,7 +157,7 @@ namespace OutSystems.Maps.MapAPI.MapManager {
 		map.dispose();
 
 		//Let's remove the empty markers references from the Markers API.
-		MarkerManager.RemoveAllMarkers(mapId, false);
+		MarkerManager.RemoveAllMarkersCreatedByAPI(mapId, false);
 	}
 
 	/**

--- a/src/OutSystems/Maps/MapAPI/MarkerManager.ts
+++ b/src/OutSystems/Maps/MapAPI/MarkerManager.ts
@@ -33,6 +33,21 @@ namespace OutSystems.Maps.MapAPI.MarkerManager {
 	}
 
 	/**
+	 * Cleans the markerMap and markerArr from the marker with the given id.
+	 *
+	 * @param {string} markerId Id of the Marker to be removed
+	 */
+	function CleanMarkerArrays(markerId: string): void {
+		markerMap.has(markerId) && markerMap.delete(markerId);
+		markerArr.splice(
+			markerArr.findIndex((marker) => {
+				return marker?.equalsToID(markerId);
+			}),
+			1
+		);
+	}
+
+	/**
 	 * Creates and adds a marker to a map.
 	 *
 	 * @export
@@ -285,6 +300,46 @@ namespace OutSystems.Maps.MapAPI.MarkerManager {
 				}),
 				1
 			);
+			marker.map?.removeMarker(markerId);
+
+			CleanMarkerArrays(markerId);
+		} catch (error) {
+			responseObj.isSuccess = false;
+			responseObj.message = error.message;
+			responseObj.code = OSFramework.Maps.Enum.ErrorCodes.API_FailedRemoveMarker;
+		}
+
+		return JSON.stringify(responseObj);
+	}
+
+	/**
+	 * Removes all the markers created by the API.
+	 *
+	 * @export
+	 * @return {*}  {string}
+	 */
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	export function RemoveAllMarkersCreatedByAPI(mapId: string, removeFromMap = true): string {
+		const responseObj = {
+			isSuccess: true,
+			message: 'Success',
+			code: '200',
+		};
+		try {
+			if (removeFromMap) {
+				// First we try to remove the markers from the map.
+				MapManager.RemoveMarkers(mapId);
+			}
+
+			for (const [storedMarkerId, storedMapId] of markerMap) {
+				if (storedMapId === mapId) {
+					const marker = GetMarkerById(storedMarkerId, false);
+					if (marker && marker.widgetId === undefined) {
+						// If the marker does not have a widgetId, it means it was created by
+						CleanMarkerArrays(storedMarkerId);
+					}
+				}
+			}
 		} catch (error) {
 			responseObj.isSuccess = false;
 			responseObj.message = error.message;
@@ -316,13 +371,7 @@ namespace OutSystems.Maps.MapAPI.MarkerManager {
 			// Second remove the markers to destroy from local variables.
 			markerMap.forEach((storedMapId, storedMarkerId) => {
 				if (mapId === storedMapId) {
-					markerMap.delete(storedMarkerId);
-					markerArr.splice(
-						markerArr.findIndex((p) => {
-							return p && p.equalsToID(storedMarkerId);
-						}),
-						1
-					);
+					CleanMarkerArrays(storedMarkerId);
 				}
 			});
 		} catch (error) {


### PR DESCRIPTION
This PR is for fixing an error that occurred when a map that contained markers that were created by Marker block (low-code), were destroyed.

### What was happening
* The map when being destroyed was removing all markers, in high-code, as to avoid memory leaks when the markers were created via API.
* As the markers blocks (Low-Code) were destroyed after the map block (Low-Code) is destroyed, the marker is not found and throws and exception.

### What was done
* Created a new API to remove only markers that were created via API (markers that don't have the widget ID)
* Invoked the new function when the map is being destroyed.
* Allow Markers to destroy themselves.

### Test Steps
1. Enter the test page
2. Destroy the map
3. See if the markers being destroyed don't throw an error

### Checklist
* [x] tested locally
* [x] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

