### PR TITLE
ROU-12552: Replace Snyk with Wiz ignores

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,4 +5,4 @@ dist
 *.d.ts
 *.js
 # don't lint settings
-*.snyk
+.wiz

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,4 +8,4 @@ node_modules
 *.css
 
 # don't lint settings
-.snyk
+.wiz

--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,0 @@
-exclude:
- global:
-   - styles/**
-   - jobs/**
-   - docs/**

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -9,4 +9,4 @@ src/static/**
 *.css
 
 # don't lint settings
-*.snyk
+.wiz

--- a/.wiz
+++ b/.wiz
@@ -1,8 +1,8 @@
 ignore:
     global_paths:
-        "styles/**":
+        /styles/**:
             reason: BY_DESIGN
-        "jobs/**":
+        /jobs/**:
             reason: BY_DESIGN
-        "docs/**":
+        /docs/**:
             reason: BY_DESIGN

--- a/.wiz
+++ b/.wiz
@@ -1,0 +1,8 @@
+ignore:
+    global_paths:
+        "styles/**":
+            reason: BY_DESIGN
+        "jobs/**":
+            reason: BY_DESIGN
+        "docs/**":
+            reason: BY_DESIGN


### PR DESCRIPTION
- Replace Snyk with Wiz ignores
- The `.wiz` file needs to follow the syntax from [this](https://docs.wiz.io/docs/exception-management-with-wiz-code#configuration-file-wiz) documentation, which is the closest to the same rules from Snyk that can be checked [here](https://docs.snyk.io/scan-with-snyk/import-project-repository/exclude-directories-and-files-from-project-import).

### Checklist

-   [ ] tested locally
-   [ ] documented the code
-   [ ] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)