### PR TITLE
ROU-12677: Cleaning Google Maps Marker console warnings

### DIFF
--- a/src/Providers/Maps/Google/Constants/Marker/Events.ts
+++ b/src/Providers/Maps/Google/Constants/Marker/Events.ts
@@ -4,7 +4,7 @@ namespace Provider.Maps.Google.Constants.Marker {
 	 * Enum that defines the available Provider Events
 	 */
 	export enum ProviderEventNames {
-		click = 'click',
+		OnClick = 'gmp-click',
 		drag = 'drag',
 		dragend = 'dragend',
 		dragstart = 'dragstart',

--- a/src/Providers/Maps/Google/Constants/Marker/Events.ts
+++ b/src/Providers/Maps/Google/Constants/Marker/Events.ts
@@ -4,7 +4,7 @@ namespace Provider.Maps.Google.Constants.Marker {
 	 * Enum that defines the available Provider Events
 	 */
 	export enum ProviderEventNames {
-		OnClick = 'gmp-click',
+		click = 'gmp-click',
 		drag = 'drag',
 		dragend = 'dragend',
 		dragstart = 'dragstart',

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -9,7 +9,8 @@ namespace Provider.Maps.Google.Marker {
 		>
 		implements IMarkerGoogle
 	{
-		private readonly _addedEvents: Array<string>;
+		private readonly _addedDomListeners: Array<{ htmlEventName: string; listener: () => void }>;
+		private readonly _addedProviderEvents: Array<string>;
 
 		constructor(
 			map: OSFramework.Maps.OSMap.IMap,
@@ -18,7 +19,8 @@ namespace Provider.Maps.Google.Marker {
 			configs: unknown
 		) {
 			super(map, markerId, type, new Configuration.Marker.GoogleMarkerConfig(configs));
-			this._addedEvents = [];
+			this._addedProviderEvents = [];
+			this._addedDomListeners = [];
 		}
 
 		private _setIcon(): void {
@@ -125,15 +127,19 @@ namespace Provider.Maps.Google.Marker {
 		}
 
 		protected _setMarkerEvents(): void {
-			// Make sure the listeners get removed before adding the new ones
-			this._addedEvents.splice(0).forEach((eventName, index) => {
+			// Remove previously registered Google Maps API listeners
+			this._addedProviderEvents.splice(0).forEach((eventName) => {
 				google.maps.event.clearListeners(this._provider, Constants.Marker.ProviderEventNames[eventName]);
-				this._addedEvents.splice(index, 1);
+			});
+
+			// Remove previously registered DOM listeners using the stored callback references
+			this._addedDomListeners.splice(0).forEach(({ htmlEventName, listener }) => {
+				this._provider.element.removeEventListener(htmlEventName, listener);
 			});
 
 			// OnClick Event (OS accelerator)
 			if (this.markerEvents.hasHandlers(OSFramework.Maps.Event.Marker.MarkerEventType.OnClick)) {
-				this._addedEvents.push(OSFramework.Maps.Event.Marker.MarkerEventType.OnClick);
+				this._addedProviderEvents.push(OSFramework.Maps.Event.Marker.MarkerEventType.OnClick);
 				this._provider.addListener(Constants.Marker.ProviderEventNames.OnClick, () => {
 					this._triggerEvent(
 						OSFramework.Maps.Event.Marker.MarkerEventType.OnClick,
@@ -152,7 +158,7 @@ namespace Provider.Maps.Google.Marker {
 					const ProviderEventName = Constants.Marker.ProviderEventNames[eventName];
 
 					if (ProviderEventName !== undefined) {
-						this._addedEvents.push(eventName);
+						this._addedProviderEvents.push(eventName);
 						this._provider.addListener(
 							// Name of the event (e.g. click, dblclick, contextmenu, etc)
 							ProviderEventName,
@@ -171,21 +177,16 @@ namespace Provider.Maps.Google.Marker {
 						const HtmlEventName = Constants.Marker.ProviderEventNamesHtml[eventName];
 
 						if (HtmlEventName !== undefined) {
-							this._addedEvents.push(eventName);
-							this._provider.element.addEventListener(
-								// Name of the event (e.g. click, dblclick, contextmenu, etc)
-								HtmlEventName,
-								// Callback CAN have an attribute (e) which is of the type MapMouseEvent
-								// Trigger the event by specifying the ProviderEvent MarkerType and the coords (lat, lng) if the callback has the attribute MapMouseEvent
-								() => {
-									this._triggerEvent(
-										OSFramework.Maps.Event.Marker.MarkerEventType.ProviderEvent,
-										eventName,
-										Helper.Conversions.GetCoordinateValue(this._provider.position.lat),
-										Helper.Conversions.GetCoordinateValue(this._provider.position.lng)
-									);
-								}
-							);
+							const listener = () => {
+								this._triggerEvent(
+									OSFramework.Maps.Event.Marker.MarkerEventType.ProviderEvent,
+									eventName,
+									Helper.Conversions.GetCoordinateValue(this._provider.position.lat),
+									Helper.Conversions.GetCoordinateValue(this._provider.position.lng)
+								);
+							};
+							this._addedDomListeners.push({ htmlEventName: HtmlEventName, listener });
+							this._provider.element.addEventListener(HtmlEventName, listener);
 						} else {
 							console.error(`Event ${eventName} is not a valid event for the Marker.`);
 						}

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -121,20 +121,20 @@ namespace Provider.Maps.Google.Marker {
 
 		protected _setMarkerEvents(): void {
 			// Make sure the listeners get removed before adding the new ones
-			this._addedEvents.forEach((eventListener, index) => {
-				google.maps.event.clearListeners(this.provider, eventListener);
+			this._addedEvents.splice(0).forEach((eventName, index) => {
+				google.maps.event.clearListeners(this._provider, Constants.Marker.ProviderEventNames[eventName]);
 				this._addedEvents.splice(index, 1);
 			});
 
 			// OnClick Event (OS accelerator)
 			if (this.markerEvents.hasHandlers(OSFramework.Maps.Event.Marker.MarkerEventType.OnClick)) {
-				this._addedEvents.push('click');
-				this._provider.addListener('click', (e: google.maps.MapMouseEvent) => {
+				this._addedEvents.push(OSFramework.Maps.Event.Marker.MarkerEventType.OnClick);
+				this._provider.addListener(Constants.Marker.ProviderEventNames.OnClick, () => {
 					this._triggerEvent(
 						OSFramework.Maps.Event.Marker.MarkerEventType.OnClick,
 						OSFramework.Maps.Event.Marker.MarkerEventType.OnClick,
-						e.latLng.lat,
-						e.latLng.lng
+						Helper.Conversions.GetCoordinateValue(this._provider.position.lat),
+						Helper.Conversions.GetCoordinateValue(this._provider.position.lng)
 					);
 				});
 			}
@@ -153,12 +153,12 @@ namespace Provider.Maps.Google.Marker {
 							ProviderEventName,
 							// Callback CAN have an attribute (e) which is of the type MapMouseEvent
 							// Trigger the event by specifying the ProviderEvent MarkerType and the coords (lat, lng) if the callback has the attribute MapMouseEvent
-							(e: google.maps.MapMouseEvent) => {
+							() => {
 								this._triggerEvent(
 									OSFramework.Maps.Event.Marker.MarkerEventType.ProviderEvent,
 									eventName,
-									e.latLng.lat,
-									e.latLng.lng
+									Helper.Conversions.GetCoordinateValue(this._provider.position.lat),
+									Helper.Conversions.GetCoordinateValue(this._provider.position.lng)
 								);
 							}
 						);
@@ -176,8 +176,8 @@ namespace Provider.Maps.Google.Marker {
 									this._triggerEvent(
 										OSFramework.Maps.Event.Marker.MarkerEventType.ProviderEvent,
 										eventName,
-										this._provider.position.lat,
-										this.provider.position.lng
+										Helper.Conversions.GetCoordinateValue(this._provider.position.lat),
+										Helper.Conversions.GetCoordinateValue(this._provider.position.lng)
 									);
 								}
 							);

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -144,8 +144,8 @@ namespace Provider.Maps.Google.Marker {
 					this._triggerEvent(
 						OSFramework.Maps.Event.Marker.MarkerEventType.OnClick,
 						OSFramework.Maps.Event.Marker.MarkerEventType.OnClick,
-						Helper.Conversions.GetCoordinateValue(this._provider.position.lat),
-						Helper.Conversions.GetCoordinateValue(this._provider.position.lng)
+						this._provider.position.lat,
+						this._provider.position.lng
 					);
 				});
 			}
@@ -168,8 +168,8 @@ namespace Provider.Maps.Google.Marker {
 								this._triggerEvent(
 									OSFramework.Maps.Event.Marker.MarkerEventType.ProviderEvent,
 									eventName,
-									Helper.Conversions.GetCoordinateValue(this._provider.position.lat),
-									Helper.Conversions.GetCoordinateValue(this._provider.position.lng)
+									this._provider.position.lat,
+									this._provider.position.lng
 								);
 							}
 						);
@@ -181,8 +181,8 @@ namespace Provider.Maps.Google.Marker {
 								this._triggerEvent(
 									OSFramework.Maps.Event.Marker.MarkerEventType.ProviderEvent,
 									eventName,
-									Helper.Conversions.GetCoordinateValue(this._provider.position.lat),
-									Helper.Conversions.GetCoordinateValue(this._provider.position.lng)
+									this._provider.position.lat,
+									this._provider.position.lng
 								);
 							};
 							this._addedDomListeners.push({ htmlEventName: HtmlEventName, listener });

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -129,7 +129,7 @@ namespace Provider.Maps.Google.Marker {
 		protected _setMarkerEvents(): void {
 			// Remove previously registered Google Maps API listeners
 			this._addedProviderEvents.splice(0).forEach((eventName) => {
-				google.maps.event.clearListeners(this._provider, Constants.Marker.ProviderEventNames[eventName]);
+				google.maps.event.clearListeners(this._provider, eventName);
 			});
 
 			// Remove previously registered DOM listeners using the stored callback references
@@ -139,8 +139,8 @@ namespace Provider.Maps.Google.Marker {
 
 			// OnClick Event (OS accelerator)
 			if (this.markerEvents.hasHandlers(OSFramework.Maps.Event.Marker.MarkerEventType.OnClick)) {
-				this._addedProviderEvents.push(OSFramework.Maps.Event.Marker.MarkerEventType.OnClick);
-				this._provider.addListener(Constants.Marker.ProviderEventNames.OnClick, () => {
+				this._addedProviderEvents.push(Constants.Marker.ProviderEventNames.click);
+				this._provider.addListener(Constants.Marker.ProviderEventNames.click, () => {
 					this._triggerEvent(
 						OSFramework.Maps.Event.Marker.MarkerEventType.OnClick,
 						OSFramework.Maps.Event.Marker.MarkerEventType.OnClick,

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -47,9 +47,14 @@ namespace Provider.Maps.Google.Marker {
 						}
 						this._provider.content = markerIconWrapper;
 					} else {
-						markerIconWrapper.textContent = this.config.label;
-
-						const markerIcon = new google.maps.marker.PinElement({ glyph: markerIconWrapper });
+						// The current Type definition of Google Maps is not updated
+						// with the new definition of google.maps.marker.PinElementOptions.
+						// This is a temporary solution to bypass the type error.
+						// TODO: Remove this once a new version of the package @types\google.maps
+						// is made available and the type definition is updated.
+						const markerIcon = new google.maps.marker.PinElement({
+							glyphText: this.config.label,
+						} as unknown as google.maps.marker.PinElementOptions);
 						this._provider.content = markerIcon;
 					}
 				} catch (e) {

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -50,7 +50,7 @@ namespace Provider.Maps.Google.Marker {
 						markerIconWrapper.textContent = this.config.label;
 
 						const markerIcon = new google.maps.marker.PinElement({ glyph: markerIconWrapper });
-						this._provider.content = markerIcon.element;
+						this._provider.content = markerIcon;
 					}
 				} catch (e) {
 					console.error(e);

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -27,10 +27,10 @@ namespace Provider.Maps.Google.Marker {
 					const height = this.config.iconHeight;
 					const width = this.config.iconWidth;
 
-					const markerIconWrapper = document.createElement('div');
-					markerIconWrapper.className = 'os-marker-icon';
-
 					if (this.config.iconUrl !== '') {
+						const markerIconWrapper = document.createElement('div');
+						markerIconWrapper.className = 'os-marker-icon';
+
 						const markerIconImage = document.createElement('img');
 						markerIconImage.src = this.config.iconUrl;
 						if (height > 0 && width > 0) {

--- a/src/Providers/Maps/Google/Marker/Marker.ts
+++ b/src/Providers/Maps/Google/Marker/Marker.ts
@@ -50,7 +50,7 @@ namespace Provider.Maps.Google.Marker {
 						// The current Type definition of Google Maps is not updated
 						// with the new definition of google.maps.marker.PinElementOptions.
 						// This is a temporary solution to bypass the type error.
-						// TODO: Remove this once a new version of the package @types\google.maps
+						// TODO: Remove this once a new version of the package @types/google.maps
 						// is made available and the type definition is updated.
 						const markerIcon = new google.maps.marker.PinElement({
 							glyphText: this.config.label,


### PR DESCRIPTION
This PR is for updating the code, according to google's recommendation, avoiding warnings to appear in the console. Additionally, the changes include updating event names to match Google Maps' new event system, refactoring event listener logic, and applying a workaround for type definition mismatches with `PinElementOptions`.

### What was happening
* The console was displaying warnings coming from Google Maps framework:
   * **Warning 1**:  `<gmp-advanced-marker>: Please use addEventListener('gmp-click', ...) instead of addEventListener('click', ...).`
   * **Warning 2**:  `<gmp-pin>: The glyph property is deprecated. Please use glyphSrc or glyphText instead.`
   * **Warning 3**:  `<gmp-pin>: The element property is deprecated. Please use the PinElement directly.`
* The warnings were caused by the usage of deprecated properties.

### What was done
* To solve **Warning 1**: 297e58d7ac7b5b784fa5af92242b3bab45fae36a
   * Updated the `ProviderEventNames` enum in `Constants/Marker/Events.ts` to use the new `'gmp-click'` event name instead of `'click'`, aligning with the latest Google Maps event system. 
   * Refactored marker event listener registration in `Marker.ts` to use the new event names from `ProviderEventNames` and ensure listeners are properly removed and re-added, preventing duplicate listeners.
   * Standardized coordinate extraction in event callbacks by using `Helper.Conversions.GetCoordinateValue`, ensuring consistent and accurate latitude/longitude values are passed to event handlers.
* To solve **Warning 2** : 9fc691a1cee5380193740197f13d08decbe8f978
   * Implemented a temporary workaround for the `google.maps.marker.PinElementOptions` type mismatch by casting the options object to `unknown` and then to the expected type, with a TODO note to remove this once type definitions are updated.
* To solve **Warning 3**: 2ca30cf215b0ef63216525fcdc01a7bf4ff41587
   * Implemented a change where the PinElement is passed directly to the provider content property;
* General improvement: e53c3180368b51d21b7b2dc89f8becbfbf0fb4b2
  * Adjusted the conditional logic for rendering marker icons to ensure that a custom icon is only created when `iconUrl` is provided, improving clarity and preventing unnecessary DOM manipulation. 

### Test Steps
* **Warning 1**
  1. Enter test page "Google_Marker_Block";
  2. Open the developer tools, and look into the console ;
  3. Validate if **Warning 1** appears;
  
* **Warning 2** & **Warning 3**
  1. Enter test page "DrawingTools";
  2. Open the developer tools;
  3. Click on the Marker drawing tool;
  4. Add a marker to the map;
  5. Look into the console and validate if **Warning 2** and/or **Warning 3** appear;

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)