### PR TITLE
ROU-12679: Fix mouse icon after disabling drawing

### DIFF
--- a/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
+++ b/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
@@ -208,7 +208,8 @@ namespace Provider.DrawingTools.TerraDraw {
 
 		public dispose(): void {
 			if (this.isReady) {
-				// Sets the mode to select to reset the mouse icon to the default value
+				// Resets the mouse icon to its default state. 
+				// This prevents the tool's custom mouse icon from persisting after the provider is destroyed.
 				this._provider.setMode(Constants.ModeName.Select);
 				this._provider.stop();
 				this._ui?.dispose();
@@ -234,7 +235,8 @@ namespace Provider.DrawingTools.TerraDraw {
 			tool && this._modeToTool.delete(tool.type);
 
 			if (this.isReady) {
-				// Sets the mode to select to reset the mouse icon to the default value
+				// Resets the mouse icon to its default state. 
+				// This prevents the tool's custom mouse icon from persisting after the provider is destroyed.
 				this._provider.setMode(Constants.ModeName.Select);
 
 				this._buildTerraDraw();

--- a/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
+++ b/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
@@ -208,6 +208,7 @@ namespace Provider.DrawingTools.TerraDraw {
 
 		public dispose(): void {
 			if (this.isReady) {
+				// Sets the mode to select to reset the mouse icon to the default value
 				this._provider.setMode(Constants.ModeName.Select);
 				this._provider.stop();
 				this._ui?.dispose();
@@ -233,6 +234,7 @@ namespace Provider.DrawingTools.TerraDraw {
 			tool && this._modeToTool.delete(tool.type);
 
 			if (this.isReady) {
+				// Sets the mode to select to reset the mouse icon to the default value
 				this._provider.setMode(Constants.ModeName.Select);
 
 				this._buildTerraDraw();

--- a/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
+++ b/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
@@ -208,6 +208,7 @@ namespace Provider.DrawingTools.TerraDraw {
 
 		public dispose(): void {
 			if (this.isReady) {
+				this._provider.setMode(Constants.ModeName.Select);
 				this._provider.stop();
 				this._ui?.dispose();
 			}

--- a/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
+++ b/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
@@ -228,13 +228,13 @@ namespace Provider.DrawingTools.TerraDraw {
 		public removeTool(toolId: string): void {
 			const tool = this.getTool(toolId);
 
-			this._provider.setMode(Constants.ModeName.Select);
-			
 			super.removeTool(toolId);
 
 			tool && this._modeToTool.delete(tool.type);
 
 			if (this.isReady) {
+				this._provider.setMode(Constants.ModeName.Select);
+
 				this._buildTerraDraw();
 
 				this._provider.start();

--- a/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
+++ b/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
@@ -228,6 +228,8 @@ namespace Provider.DrawingTools.TerraDraw {
 		public removeTool(toolId: string): void {
 			const tool = this.getTool(toolId);
 
+			this._provider.setMode(Constants.ModeName.Select);
+			
 			super.removeTool(toolId);
 
 			tool && this._modeToTool.delete(tool.type);


### PR DESCRIPTION
This PR is to fix the mouse icon after disbling the drawing tools


### What was happening
* When the user selected a drawing tool and then disabled the drawing tool the mouse icon remains the drawing one (crosshair) 

### What was done
* When the drawing tool is disposed, the state is restored to the default one to ensure the mouse icon is also restored 

### Test Steps
1. Open the sample application 
2. Click on the add marker button
3. Add one marker
4. Disable drawing tools
5. Place the mouse over the map
6. Validate that the cursor is the hand to pan the map


### Screenshots

![Screen Recording 2026-04-01 at 11 57 22](https://github.com/user-attachments/assets/6b85b6ec-13b8-43d7-916b-d40f47184be3)

![maps-drawingtools-cursor-icon-problem](https://github.com/user-attachments/assets/f8344af0-906f-4843-b9a4-968e4e1cdfda)


### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

