### PR TITLE
ROU-12717: Fix name of added event to marker pop-up

### DIFF
--- a/src/Providers/Maps/Google/Marker/MarkerPopup.ts
+++ b/src/Providers/Maps/Google/Marker/MarkerPopup.ts
@@ -4,7 +4,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace Provider.Maps.Google.Marker {
 	export class MarkerPopup extends Marker implements OSFramework.Maps.Marker.IMarkerPopup {
-		private _contentString: string;
+		private _contentString: string = '';
 
 		protected _setMarkerEvents(): void {
 			super._setMarkerEvents();
@@ -36,9 +36,10 @@ namespace Provider.Maps.Google.Marker {
 		}
 
 		public refreshPopupContent(): void {
-			this._contentString = OSFramework.Maps.Helper.GetElementByUniqueId(this.uniqueId).querySelector(
-				OSFramework.Maps.Helper.Constants.markerPopup
-			).innerHTML;
+			this._contentString =
+				OSFramework.Maps.Helper.GetElementByUniqueId(this.uniqueId)?.querySelector(
+					OSFramework.Maps.Helper.Constants.markerPopup
+				)?.innerHTML ?? '';
 			this.map.features.infoWindow.setPopupContent(this._contentString);
 		}
 	}

--- a/src/Providers/Maps/Google/Marker/MarkerPopup.ts
+++ b/src/Providers/Maps/Google/Marker/MarkerPopup.ts
@@ -12,7 +12,7 @@ namespace Provider.Maps.Google.Marker {
 			// Open the popup when the user clicks on the Marker
 			// To close the Marker click on it and then use the ESC or the "x" on the top right corner of the popup
 			// Or use the API method - closePopup()
-			this._provider.addListener('click', () => {
+			this._provider.addListener(Constants.Marker.ProviderEventNames.click, () => {
 				this.refreshPopupContent();
 				this.openPopup();
 			});


### PR DESCRIPTION
This PR is for simply attaching to the correct event in the case of the Google Advanced Marker. For the new version of the markers, the click event is `gmp-click` and not `click`.

### What was happening
* An warning was appearing in the console, when the click occurred.

### What was done
* Changed the static string to use instead the enumerate with the correct provider event;
* Protected the code against errors;

### Test Steps
1. Go to the test page;
2. Click on the marker;
3. See if the pop-up appears;
4. And if no warning appears in the console;

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

