### PR TITLE
ROU-12774: Fix TerraDraw dispose crash and TypeScript type errors   

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OutSystems Maps · v2.3.0
+# OutSystems Maps · v2.3.1
 
 ![GitHub License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg) ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
 

--- a/gulp/DefaultSpecs.js
+++ b/gulp/DefaultSpecs.js
@@ -19,7 +19,7 @@ const constants = {
 
 // Store the default project specifications
 const specs = {
-	version: '2.3.0',
+	version: '2.3.1',
 	name: 'OutSystems Maps',
 	description: '',
 	url: 'Website:\n • ' + constants.websiteUrl,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outsystems-maps",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "OutSystems Maps",
   "author": "UI Components Team",
   "license": "BSD-3-Clause",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,3 +16,10 @@ sonar.exclusions=**/node_modules/**,**/dist/**,**/*.min.js
 
 # JavaScript/TypeScript settings
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# Suppress S7764 (prefer globalThis over window) project-wide.
+# Runtime-injected browser globals are declared via `interface Window` augmentation
+# in Global.d.ts — `window.x` is the only access pattern TypeScript resolves correctly.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S7764
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.ts

--- a/src/OSFramework/Maps/Constants.ts
+++ b/src/OSFramework/Maps/Constants.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.Maps.Constants {
 	/* OutSystems Maps Version */
-	export const OSMapsVersion = '2.3.0';
+	export const OSMapsVersion = '2.3.1';
 
 	/**
 	 * Maps Set OutSystems platform in use (O11/ODC).

--- a/src/Providers/DrawingTools/TerraDraw/Configuration/DrawConfig.ts
+++ b/src/Providers/DrawingTools/TerraDraw/Configuration/DrawConfig.ts
@@ -8,6 +8,6 @@ namespace Provider.DrawingTools.TerraDraw.Configuration {
 		public allowDrag: boolean;
 		public uniqueId: string;
 
-		public abstract getProviderConfig(): unknown[];
+		public abstract getProviderConfig(): unknown;
 	}
 }

--- a/src/Providers/DrawingTools/TerraDraw/Configuration/DrawFilledShapeConfig.ts
+++ b/src/Providers/DrawingTools/TerraDraw/Configuration/DrawFilledShapeConfig.ts
@@ -17,7 +17,7 @@ namespace Provider.DrawingTools.TerraDraw.Configuration {
 		 *   strokeWeight  → styles.outlineWidth
 		 *   strokeOpacity → styles.outlineOpacity
 		 */
-		public getProviderConfig(): unknown[] {
+		public getProviderConfig(): unknown {
 			return {
 				styles: {
 					fillColor: this.fillColor ?? '#aaaaaa',
@@ -26,7 +26,7 @@ namespace Provider.DrawingTools.TerraDraw.Configuration {
 					outlineWidth: this.strokeWeight ?? 2,
 					outlineOpacity: this.strokeOpacity ?? 1,
 				},
-			} as unknown as unknown[];
+			};
 		}
 	}
 }

--- a/src/Providers/DrawingTools/TerraDraw/Configuration/DrawMarkerConfig.ts
+++ b/src/Providers/DrawingTools/TerraDraw/Configuration/DrawMarkerConfig.ts
@@ -14,12 +14,12 @@ namespace Provider.DrawingTools.TerraDraw.Configuration {
 	export class DrawMarkerConfig extends DrawConfig {
 		public iconUrl: string;
 
-		public getProviderConfig(): unknown[] {
+		public getProviderConfig(): unknown {
 			return {
 				styles: {
 					markerUrl: this.iconUrl ?? '',
 				},
-			} as unknown as unknown[];
+			};
 		}
 	}
 }

--- a/src/Providers/DrawingTools/TerraDraw/Configuration/DrawPolylineConfig.ts
+++ b/src/Providers/DrawingTools/TerraDraw/Configuration/DrawPolylineConfig.ts
@@ -12,14 +12,14 @@ namespace Provider.DrawingTools.TerraDraw.Configuration {
 	 *   strokeOpacity → styles.lineStringOpacity
 	 */
 	export class DrawPolylineConfig extends DrawBasicShapeConfig {
-		public getProviderConfig(): unknown[] {
+		public getProviderConfig(): unknown {
 			return {
 				styles: {
 					lineStringColor: this.strokeColor ?? '#555555',
 					lineStringWidth: this.strokeWeight ?? 2,
 					lineStringOpacity: this.strokeOpacity ?? 1,
 				},
-			} as unknown as unknown[];
+			};
 		}
 	}
 }

--- a/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
+++ b/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
@@ -208,10 +208,13 @@ namespace Provider.DrawingTools.TerraDraw {
 
 		public dispose(): void {
 			if (this.isReady) {
-				// Resets the mouse icon to its default state. 
-				// This prevents the tool's custom mouse icon from persisting after the provider is destroyed.
-				this._provider.setMode(Constants.ModeName.Select);
-				this._provider.stop();
+				// If the provider is not enabled, means that it was never started.
+				if (this.provider.enabled) {
+					// Resets the mouse icon to its default state.
+					// This prevents the tool's custom mouse icon from persisting after the provider is destroyed.
+					this._provider.setMode(Constants.ModeName.Select);
+					this._provider.stop();
+				}
 				this._ui?.dispose();
 			}
 			this._provider = undefined;

--- a/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
+++ b/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
@@ -208,7 +208,7 @@ namespace Provider.DrawingTools.TerraDraw {
 
 		public dispose(): void {
 			if (this.isReady) {
-				// If the provider is not enabled, means that it was never started.
+				// If the provider is not enabled, it means that it was never started.
 				if (this.provider.enabled) {
 					// Resets the mouse icon to its default state.
 					// This prevents the tool's custom mouse icon from persisting after the provider is destroyed.
@@ -238,7 +238,7 @@ namespace Provider.DrawingTools.TerraDraw {
 			tool && this._modeToTool.delete(tool.type);
 
 			if (this.isReady) {
-				// If the provider is not enabled, means that it was never started.
+				// If the provider is not enabled, it means that it was never started.
 				if (this.provider.enabled) {
 					// Resets the mouse icon to its default state.
 					// This prevents the tool's custom mouse icon from persisting after the provider is destroyed.

--- a/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
+++ b/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
@@ -238,7 +238,7 @@ namespace Provider.DrawingTools.TerraDraw {
 			tool && this._modeToTool.delete(tool.type);
 
 			if (this.isReady) {
-				// Resets the mouse icon to its default state. 
+				// Resets the mouse icon to its default state.
 				// This prevents the tool's custom mouse icon from persisting after the provider is destroyed.
 				this._provider.setMode(Constants.ModeName.Select);
 

--- a/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
+++ b/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
@@ -67,7 +67,7 @@ namespace Provider.DrawingTools.TerraDraw {
 		 * support hot-swapping modes, so the entire instance must be replaced.
 		 */
 		private _buildTerraDraw(): void {
-			if (this._provider) {
+			if (this._provider?.enabled) {
 				this._provider.stop();
 			}
 

--- a/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
+++ b/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
@@ -238,10 +238,12 @@ namespace Provider.DrawingTools.TerraDraw {
 			tool && this._modeToTool.delete(tool.type);
 
 			if (this.isReady) {
-				// Resets the mouse icon to its default state.
-				// This prevents the tool's custom mouse icon from persisting after the provider is destroyed.
-				this._provider.setMode(Constants.ModeName.Select);
-
+				// If the provider is not enabled, means that it was never started.
+				if (this.provider.enabled) {
+					// Resets the mouse icon to its default state.
+					// This prevents the tool's custom mouse icon from persisting after the provider is destroyed.
+					this._provider.setMode(Constants.ModeName.Select);
+				}
 				this._buildTerraDraw();
 
 				this._provider.start();

--- a/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
+++ b/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
@@ -35,7 +35,7 @@ namespace Provider.DrawingTools.TerraDraw {
 
 			// Always include a select mode so the user can deselect drawing without reloading
 			modes.push(
-				new globalThis.terraDraw.TerraDrawSelectMode({
+				new window.terraDraw.TerraDrawSelectMode({
 					flags: {
 						circle: { feature: { draggable: true } },
 						linestring: {
@@ -71,7 +71,7 @@ namespace Provider.DrawingTools.TerraDraw {
 				this._provider.stop();
 			}
 
-			this._provider = new globalThis.terraDraw.TerraDraw({
+			this._provider = new window.terraDraw.TerraDraw({
 				adapter: this._getAdapter(),
 				modes: this._buildModes(),
 			}) as TerraDrawProviderCompatible;
@@ -93,7 +93,7 @@ namespace Provider.DrawingTools.TerraDraw {
 
 		private _getAdapter(): TerraDrawGoogleMapsAdapter {
 			if (this.config.providerType === OSFramework.Maps.Enum.ProviderType.Google) {
-				return new globalThis.terraDrawGoogleMapsAdapter.TerraDrawGoogleMapsAdapter({
+				return new window.terraDrawGoogleMapsAdapter.TerraDrawGoogleMapsAdapter({
 					map: this.map.provider as google.maps.Map,
 					lib: google.maps,
 					coordinatePrecision: 9,

--- a/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
+++ b/src/Providers/DrawingTools/TerraDraw/DrawingTools.ts
@@ -74,7 +74,7 @@ namespace Provider.DrawingTools.TerraDraw {
 			this._provider = new window.terraDraw.TerraDraw({
 				adapter: this._getAdapter(),
 				modes: this._buildModes(),
-			}) as TerraDrawProviderCompatible;
+			});
 
 			this._provider.on('finish', (id, context) => this._onFinish(id, context));
 
@@ -196,9 +196,9 @@ namespace Provider.DrawingTools.TerraDraw {
 		}
 
 		public changeProperty(propertyName: string, value: unknown): void {
-			const propValue = OSFramework.Maps.Enum.OS_Config_DrawingTools[propertyName];
 			super.changeProperty(propertyName, value);
 			if (this.isReady) {
+				const propValue = OSFramework.Maps.Enum.OS_Config_DrawingTools[propertyName];
 				if (propValue === OSFramework.Maps.Enum.OS_Config_DrawingTools.position) {
 					const modeNames = this.tools.map((t) => t.type);
 					this._ui?.refresh(modeNames, value as string);

--- a/src/Providers/DrawingTools/TerraDraw/Tools/DrawCircle.ts
+++ b/src/Providers/DrawingTools/TerraDraw/Tools/DrawCircle.ts
@@ -88,7 +88,9 @@ namespace Provider.DrawingTools.TerraDraw.Tools {
 		}
 
 		public createTerraDrawMode(): TerraDrawBaseDrawMode {
-			return new globalThis.terraDraw.TerraDrawCircleMode(this.config.getProviderConfig());
+			return new window.terraDraw.TerraDrawCircleMode(
+				this.config.getProviderConfig() as ConstructorParameters<typeof window.terraDraw.TerraDrawCircleMode>[0]
+			);
 		}
 	}
 }

--- a/src/Providers/DrawingTools/TerraDraw/Tools/DrawMarker.ts
+++ b/src/Providers/DrawingTools/TerraDraw/Tools/DrawMarker.ts
@@ -89,7 +89,9 @@ namespace Provider.DrawingTools.TerraDraw.Tools {
 		}
 
 		public createTerraDrawMode(): TerraDrawBaseDrawMode {
-			return new globalThis.terraDraw.TerraDrawMarkerMode(this.config.getProviderConfig());
+			return new window.terraDraw.TerraDrawMarkerMode(
+				this.config.getProviderConfig() as ConstructorParameters<typeof window.terraDraw.TerraDrawMarkerMode>[0]
+			);
 		}
 	}
 }

--- a/src/Providers/DrawingTools/TerraDraw/Tools/DrawPolygon.ts
+++ b/src/Providers/DrawingTools/TerraDraw/Tools/DrawPolygon.ts
@@ -41,7 +41,9 @@ namespace Provider.DrawingTools.TerraDraw.Tools {
 		}
 
 		public createTerraDrawMode(): TerraDrawBaseDrawMode {
-			return new globalThis.terraDraw.TerraDrawPolygonMode(this.config.getProviderConfig());
+			return new window.terraDraw.TerraDrawPolygonMode(
+				this.config.getProviderConfig() as ConstructorParameters<typeof window.terraDraw.TerraDrawPolygonMode>[0]
+			);
 		}
 	}
 }

--- a/src/Providers/DrawingTools/TerraDraw/Tools/DrawPolygon.ts
+++ b/src/Providers/DrawingTools/TerraDraw/Tools/DrawPolygon.ts
@@ -42,7 +42,9 @@ namespace Provider.DrawingTools.TerraDraw.Tools {
 
 		public createTerraDrawMode(): TerraDrawBaseDrawMode {
 			return new window.terraDraw.TerraDrawPolygonMode(
-				this.config.getProviderConfig() as ConstructorParameters<typeof window.terraDraw.TerraDrawPolygonMode>[0]
+				this.config.getProviderConfig() as ConstructorParameters<
+					typeof window.terraDraw.TerraDrawPolygonMode
+				>[0]
 			);
 		}
 	}

--- a/src/Providers/DrawingTools/TerraDraw/Tools/DrawPolyline.ts
+++ b/src/Providers/DrawingTools/TerraDraw/Tools/DrawPolyline.ts
@@ -42,7 +42,9 @@ namespace Provider.DrawingTools.TerraDraw.Tools {
 
 		public createTerraDrawMode(): TerraDrawBaseDrawMode {
 			return new window.terraDraw.TerraDrawLineStringMode(
-				this.config.getProviderConfig() as ConstructorParameters<typeof window.terraDraw.TerraDrawLineStringMode>[0]
+				this.config.getProviderConfig() as ConstructorParameters<
+					typeof window.terraDraw.TerraDrawLineStringMode
+				>[0]
 			);
 		}
 	}

--- a/src/Providers/DrawingTools/TerraDraw/Tools/DrawPolyline.ts
+++ b/src/Providers/DrawingTools/TerraDraw/Tools/DrawPolyline.ts
@@ -41,7 +41,9 @@ namespace Provider.DrawingTools.TerraDraw.Tools {
 		}
 
 		public createTerraDrawMode(): TerraDrawBaseDrawMode {
-			return new globalThis.terraDraw.TerraDrawLineStringMode(this.config.getProviderConfig());
+			return new window.terraDraw.TerraDrawLineStringMode(
+				this.config.getProviderConfig() as ConstructorParameters<typeof window.terraDraw.TerraDrawLineStringMode>[0]
+			);
 		}
 	}
 }

--- a/src/Providers/DrawingTools/TerraDraw/Tools/DrawRectangle.ts
+++ b/src/Providers/DrawingTools/TerraDraw/Tools/DrawRectangle.ts
@@ -66,7 +66,9 @@ namespace Provider.DrawingTools.TerraDraw.Tools {
 
 		public createTerraDrawMode(): TerraDrawBaseDrawMode {
 			return new window.terraDraw.TerraDrawRectangleMode(
-				this.config.getProviderConfig() as ConstructorParameters<typeof window.terraDraw.TerraDrawRectangleMode>[0]
+				this.config.getProviderConfig() as ConstructorParameters<
+					typeof window.terraDraw.TerraDrawRectangleMode
+				>[0]
 			);
 		}
 	}

--- a/src/Providers/DrawingTools/TerraDraw/Tools/DrawRectangle.ts
+++ b/src/Providers/DrawingTools/TerraDraw/Tools/DrawRectangle.ts
@@ -65,7 +65,9 @@ namespace Provider.DrawingTools.TerraDraw.Tools {
 		}
 
 		public createTerraDrawMode(): TerraDrawBaseDrawMode {
-			return new globalThis.terraDraw.TerraDrawRectangleMode(this.config.getProviderConfig());
+			return new window.terraDraw.TerraDrawRectangleMode(
+				this.config.getProviderConfig() as ConstructorParameters<typeof window.terraDraw.TerraDrawRectangleMode>[0]
+			);
 		}
 	}
 }

--- a/src/Providers/Layers/deck.gl/HeatmapLayer.ts
+++ b/src/Providers/Layers/deck.gl/HeatmapLayer.ts
@@ -24,9 +24,9 @@ namespace Provider.Layers.deckgl.HeatmapLayer {
 				...(gradientColors ? { colorRange: gradientColors } : {}),
 				// Id that enables the deck.gl to perform the update to the layer.
 				id: this.uniqueId,
-			} as ConstructorParameters<typeof globalThis.deck.HeatmapLayer>[0];
+			} as ConstructorParameters<typeof window.deck.HeatmapLayer>[0];
 
-			return new globalThis.deck.HeatmapLayer(finalConfigs);
+			return new window.deck.HeatmapLayer(finalConfigs);
 		}
 
 		private _gradientColors(): DeckglColor[] | undefined {
@@ -75,7 +75,7 @@ namespace Provider.Layers.deckgl.HeatmapLayer {
 			// Creates the provider HeatmapLayer
 			this._providerHeatmapLayer = this._buildProviderLayer();
 
-			this._provider = new globalThis.deck.GoogleMapsOverlay({
+			this._provider = new window.deck.GoogleMapsOverlay({
 				layers: [this._providerHeatmapLayer],
 			});
 

--- a/src/Providers/Maps/Google/Shape/Polygon.ts
+++ b/src/Providers/Maps/Google/Shape/Polygon.ts
@@ -18,7 +18,7 @@ namespace Provider.Maps.Google.Shape {
 		protected _createProvider(path: Array<OSFramework.Maps.OSStructures.OSMap.Coordinates>): google.maps.Polygon {
 			return new google.maps.Polygon({
 				map: this.map.provider,
-				paths: path,
+				paths: path as google.maps.LatLngLiteral[],
 				...(this.getProviderConfig() as Configuration.Shape.IShapeProviderConfig),
 			});
 		}


### PR DESCRIPTION
This PR fixes a crash when disposing TerraDraw drawing tools that were never activated, and resolves several TypeScript compiler errors in the TerraDraw and deck.gl providers.

### What was happening
* Disposing a map with drawing tools configured but never activated caused a crash. `dispose()` was calling `setMode()` and `stop()` unconditionally, but TerraDraw throws when `stop()` is called on an instance that was never started (i.e., `enabled` is false).
* Using `globalThis.terraDraw`, `globalThis.terraDrawGoogleMapsAdapter`, and `globalThis.deck` caused TS error 7017. Runtime-injected browser globals are declared via `interface Window` augmentation in `Global.d.ts`, which TypeScript only resolves through `window`, not `globalThis`.
* `DrawConfig.getProviderConfig()` was typed as `unknown[]` (array), but all implementations return a plain options object `{ styles: { ... } }`. Passing `unknown[]` to TerraDraw mode constructors triggered TS2559 ("Type 'unknown[]' has no properties in common with...") across all five Draw tool classes.
* `Polygon._createProvider` passed `path` as `Array<Coordinates>` where `google.maps.LatLngLiteral[]` was expected, causing a type mismatch.

### What was done
* Guarded the `setMode()` / `stop()` calls in `dispose()` behind a `this.provider.enabled` check. If the drawing tool was built but the user never interacted with it, the TerraDraw instance is never started and must be skipped during teardown.
* Replaced `globalThis` with `window` across all TerraDraw (`DrawingTools.ts`, all `DrawXxx.ts` tools) and deck.gl (`HeatmapLayer.ts`) provider files. Added a project-level SonarCloud suppression for rule `typescript:S7764` in `sonar-project.properties` — the `window` pattern is correct here given the `Window` augmentation strategy.
* Changed `DrawConfig.getProviderConfig()` return type from `unknown[]` to `unknown`. Removed the `as unknown as unknown[]` double-cast from all three config subclasses. Updated all five `createTerraDrawMode()` callers to cast via `ConstructorParameters<typeof window.terraDraw.TerraDrawXxxMode>[0]`, which derives the expected options type directly from the constructor signature.
* Added `as google.maps.LatLngLiteral[]` cast to `path` in `Polygon._createProvider`.

### Test Steps
**Hide Drawing Tools error**
1. Enter test page
2. Hide the Drawing Tools
3. Validate that no error appears

**Type errors**
1. Run `npm run build` command
2. Validate that the build is successful


### Screenshots
(prefer animated gif)


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

