### PR TITLE
ROU-12785: Propose changes to support loading file layers in google maps using deck.gl library

### DIFF
--- a/docs/adr/ADR-0005-Self-Contained-Bundling-of-NPM-Only-Runtime-Libraries.md
+++ b/docs/adr/ADR-0005-Self-Contained-Bundling-of-NPM-Only-Runtime-Libraries.md
@@ -220,7 +220,7 @@ libraries that are **only** distributed as ESM/CJS.
 ## Links
 
 - ROU-12785 (deck.gl FileLayer — first consumer of the pattern)
-- [external_libs/README.md](../../external_libs/README.md)
+- Vendoring workflow reference: documented in this ADR
 - [loaders.gl KMLLoader documentation](https://loaders.gl/docs/modules/kml/api-reference/kml-loader)
 
 ## Date

--- a/docs/adr/ADR-0005-Self-Contained-Bundling-of-NPM-Only-Runtime-Libraries.md
+++ b/docs/adr/ADR-0005-Self-Contained-Bundling-of-NPM-Only-Runtime-Libraries.md
@@ -1,0 +1,228 @@
+<!-- This is an ADR template, follow the same convention for future ADRs -->
+
+# ADR-0005: Self-Contained Bundling of NPM-Only Runtime Libraries via external_libs Folder
+
+## Status
+
+Proposed
+
+## Context
+
+OutSystems Maps is loaded by OutSystems applications as a pre-compiled AMD module
+(`dist/OutSystemsMaps.js`). At runtime there is no npm resolution, no ES module
+loader, and no bundler available on the OutSystems platform. Any JavaScript that
+must run in the browser has to either be part of the compiled output or be
+loaded as a standalone script and exposed on `window`.
+
+This has worked well for the library's own TypeScript source — compiled by `tsc`
+to a single AMD file via the `outFile` setting in `tsconfig.json` — and for
+third-party libraries that ship browser-ready UMD/IIFE bundles (Google Maps,
+Leaflet, `@googlemaps/markerclusterer`, TerraDraw, deck.gl). Those bundles are
+loaded as standalone scripts by the OutSystems Forge component and attach
+themselves to known `window` globals.
+
+The pattern breaks when a third-party library we want to use is published **only**
+as ES Modules or CommonJS, with no browser-ready distribution:
+
+- It cannot be `import`-ed at runtime — there is no module loader on the host.
+- It cannot be inlined into our `tsc`-compiled output — `tsc` only compiles
+  TypeScript source files reachable via `///` triple-slash references; it does
+  not bundle npm dependencies.
+- Adding a full JavaScript bundler (webpack, rollup, esbuild) to the main
+  pipeline would conflate compilation of our provider-isolated TypeScript with
+  the unrelated concern of vendoring third-party runtime code, and would force a
+  migration away from the AMD `outFile` model that the Forge integration relies
+  on.
+
+The concrete trigger was the new deck.gl-based `FileLayer` (ROU-12785), which
+needed `@loaders.gl/kml` to parse KML files into GeoJSON before handing them to
+deck.gl's `GeoJsonLayer`. `@loaders.gl/kml` is published as ESM/CJS only; there
+is no official UMD distribution. The same situation is expected to recur for
+future third-party libraries.
+
+Additional constraints:
+
+- The vendored bundle must be **version-pinned and reproducible** so that any
+  future contributor can rebuild it deterministically from committed sources.
+- The main build (`npm run build`) must remain unchanged in inputs, outputs, and
+  execution time — vendoring third-party libraries should not slow down daily
+  TypeScript development.
+- TypeScript intellisense and type-checking must still resolve types for the
+  vendored libraries during authoring.
+- The output is shipped via the OutSystems Forge component, not via an npm
+  install of OutSystems Maps — there is no programmatic install/upgrade path on
+  the consumer side; the bundle must be available as a static file.
+
+## Decision Drivers
+
+- Enable runtime use of npm-only third-party libraries without introducing a
+  runtime bundler.
+- Keep the main TypeScript pipeline narrow, fast, and AMD-compatible.
+- Keep produced bundles version-pinned, reproducible, and auditable.
+- Preserve developer ergonomics: TypeScript intellisense and type-checking
+  against the libraries' real types.
+- Avoid runtime dependencies on third-party CDNs (availability, latency, supply
+  chain, CSP).
+
+## Considered Options
+
+- **Option 1: Load libraries from a public CDN (unpkg, jsDelivr, etc.) at runtime**
+  - Pros: No code committed here; transparent updates if the consumer wants
+    them.
+  - Cons: Adds an uncontrolled external runtime dependency for every OutSystems
+    app using Maps; subject to availability and latency outside our control;
+    supply-chain risk; complicates CSP configuration in enterprise OutSystems
+    environments; the Forge component cannot easily pin a specific version of
+    the library it depends on.
+
+- **Option 2: Add a bundler (rollup/webpack/esbuild) to the main `npm run build`**
+  - Pros: Single pipeline; no separate process for vendor code.
+  - Cons: Conflates compilation of our authored TypeScript (already handled
+    cleanly by `tsc` with `outFile`) with vendoring of third-party libraries;
+    introduces a transitive dependency tree into the root `package.json`;
+    increases build time on every change; abandoning `outFile` would require
+    significant rework of the Forge integration.
+
+- **Option 3: Vendor pre-built UMD files manually (download once from a CDN, commit)**
+  - Pros: Minimal tooling.
+  - Cons: Not reproducible — the committed file cannot be rebuilt from source;
+    future contributors have no way to audit or upgrade it; equivalent to
+    committing an unverifiable binary blob.
+
+- **Option 4: Self-contained bundling subfolders under `external_libs/`**
+  - Each library that needs runtime presence but is only published as ESM/CJS
+    gets its own subfolder with a pinned `package.json`, a `rollup.config.mjs`
+    producing a UMD bundle, a minimal `src/index.js` re-exporting only the
+    symbols we need, and a committed `dist/<library>.js`. The root
+    `package.json` lists the same libraries as type-only `devDependencies`
+    (consumed via `import type`) so TypeScript can resolve their types during
+    authoring without pulling them into the compiled output. Rebuilds are
+    explicit: `cd external_libs/<library> && npm install && npm run build`.
+  - Pros: Reproducible (rollup config + lockfile committed); auditable (anyone
+    can regenerate the bundle from pinned sources); isolated from the main
+    pipeline (zero impact on `npm run build`); transparent (each library
+    documents the `window` global it attaches to); upgrade path is clear (bump
+    pinned versions, rebuild, commit).
+  - Cons: Upgrading a vendored library is a two-step process (rebuild then
+    commit); the bundle output is committed to the repository, which is unusual
+    but consistent with how the platform consumes this library; each subfolder
+    is an additional dependency-management surface (its own `node_modules` and
+    lockfile).
+
+## Decision Outcome
+
+Chosen option: **Option 4 — `external_libs/` subfolders**, because it is the
+only option that:
+
+1. Enables runtime use of npm-only libraries without introducing a runtime
+   bundler.
+2. Keeps the main build pipeline narrow, fast, and AMD-compatible.
+3. Preserves reproducibility — the bundle can be regenerated from version-pinned
+   sources at any time, by anyone, in isolation from the rest of the build.
+4. Avoids runtime dependencies on third-party CDNs and the associated
+   availability, latency, CSP, and supply-chain concerns.
+
+Positive consequences:
+
+- The library can adopt new npm-only third-party dependencies through a
+  documented, repeatable pattern, without re-architecting the main pipeline.
+- Each vendored library is self-contained: its dependencies, build
+  configuration, and output live in one folder, with no entanglement with other
+  parts of the codebase.
+- The `import type` pattern in the root `package.json` keeps TypeScript
+  intellisense and type-checking fully functional during authoring, even though
+  the runtime code comes exclusively from the committed bundle.
+- The convention (one folder per library, UMD output, named `window` global)
+  generalises naturally for future libraries with the same shape — additional
+  loaders.gl modules, geometry utilities, custom layer libraries, etc.
+
+Negative consequences:
+
+- Upgrading a vendored library is a two-step process: bump the version pins in
+  the subfolder's `package.json`, rebuild, then commit the regenerated bundle
+  alongside the source change.
+- Vendored libraries form a separate dependency-management surface with their
+  own `node_modules` and lockfile; security audits and dependency scans must be
+  configured to cover them in addition to the root `package.json`.
+- The committed `dist/<library>.js` is a generated artefact tracked in version
+  control. Reviewers must remember that any change to a bundle file should
+  always be accompanied by the corresponding source change in the same
+  subfolder, and that the bundle should never be edited by hand.
+
+## Implementation Details
+
+### Folder layout
+
+```
+external_libs/
+├── README.md
+└── <library-name>/
+    ├── package.json          # pinned deps, "build" script
+    ├── rollup.config.mjs     # UMD output, named global, browser: true
+    ├── src/index.js          # re-exports only what's needed
+    ├── .gitignore            # ignores node_modules; dist/ is committed
+    └── dist/<library>.js     # committed UMD bundle
+```
+
+Current contents:
+
+| Folder | Global exposed | Bundle path |
+|---|---|---|
+| `loaders.gl/` | `window.loaders` | `loaders.gl/dist/loaders.gl.js` |
+
+### Rebuild process
+
+```bash
+cd external_libs/<library-name>
+npm install
+npm run build
+```
+
+The regenerated `dist/<library>.js` must be committed alongside the source
+change that prompted the rebuild.
+
+### Adding a new vendored library
+
+1. Create `external_libs/<library-name>/`.
+2. Add `package.json` with pinned dependencies and a
+   `rollup -c rollup.config.mjs` build script.
+3. Add `src/index.js` exporting only the symbols the OutSystems Maps source
+   needs.
+4. Add `rollup.config.mjs` targeting `format: 'umd'` with `browser: true`
+   resolution and `name: '<global>'` matching the desired `window` attachment.
+5. Add `.gitignore` for `node_modules` (commit `dist/`).
+6. Run `npm install && npm run build` in the subfolder.
+7. Add the library as a type-only `devDependency` in the root `package.json`
+   so TypeScript can resolve types via `import type`.
+8. Declare `window.<global>` in `src/Global.d.ts`.
+9. Coordinate with the Forge component to load the new bundle at runtime.
+
+### Why TypeScript types still work
+
+The root `package.json` lists the same libraries (`@loaders.gl/core`,
+`@loaders.gl/kml`, etc.) as `devDependencies`. `src/Global.d.ts` uses
+`import type` declarations to alias the library types into the global
+namespace. Because `import type` is erased at compile time, these imports have
+no impact on the AMD output produced by `tsc`. The runtime value of the global
+(e.g. `window.loaders`) comes exclusively from the bundle in
+`external_libs/<library>/dist/<library>.js`, loaded as a standalone script by
+the Forge component.
+
+### Boundary with already-UMD libraries
+
+Libraries that already ship a browser-ready UMD/IIFE distribution (Google Maps
+JS API, Leaflet, `@googlemaps/markerclusterer`, TerraDraw, deck.gl) do not
+require an `external_libs/` subfolder. They continue to be referenced as
+`devDependencies` for types only and loaded directly by the Forge component
+from their own published bundles. `external_libs/` is reserved exclusively for
+libraries that are **only** distributed as ESM/CJS.
+
+## Links
+
+- ROU-12785 (deck.gl FileLayer — first consumer of the pattern)
+- [external_libs/README.md](../../external_libs/README.md)
+- [loaders.gl KMLLoader documentation](https://loaders.gl/docs/modules/kml/api-reference/kml-loader)
+
+## Date
+
+2026-05-19

--- a/docs/adr/ADR-0006-Replace-Google-KmlLayer-with-deck-gl-FileLayer.md
+++ b/docs/adr/ADR-0006-Replace-Google-KmlLayer-with-deck-gl-FileLayer.md
@@ -1,0 +1,307 @@
+<!-- This is an ADR template, follow the same convention for future ADRs -->
+
+# ADR-0006: Replace Google KmlLayer with deck.gl-based FileLayer
+
+## Status
+
+Proposed
+
+## Context
+
+Google deprecated `google.maps.KmlLayer` on **April 30, 2026**. Per the
+official deprecation notice and KML Layer Migration Guide, the class
+remains available for existing applications but is closed to new projects
+and will be subject to removal at a future date. Google offers two
+migration paths:
+
+1. **Data-driven styling for datasets** — upload KML data to Google's
+   Maps Platform Datasets service and render it through the data-driven
+   styling APIs.
+2. **Third-party libraries** — parse KML on the client and render the
+   resulting geometry through the Data layer or any overlay (e.g.
+   deck.gl).
+
+OutSystems Maps' File Layer block has historically used `KmlLayer` as
+its rendering backend. Without a replacement, the feature becomes a
+deprecation liability and would eventually stop working entirely.
+
+Aside from the deprecation itself, `KmlLayer` carries structural
+limitations that have constrained OutSystems applications:
+
+- The KML file is fetched and parsed on Google's servers, not in the
+  browser. Files behind authentication or on internal networks cannot
+  be loaded, and the documented file-size cap (~3 MB) is enforced by
+  Google's parser, not by the consumer.
+- Styling is limited to what KML's `<Style>` definitions allow; the
+  consumer has no programmatic control over feature rendering once the
+  layer is constructed.
+- `KmlLayer` exists only in the Google Maps JS API, so the File Layer
+  block is Google-only — there is no parallel path for Leaflet.
+
+A parallel deck.gl migration for HeatmapLayer is already documented in
+ADR-0003. JIRA ROU-12785 (a Spike under epic ROU-3078) calls out the
+same approach for File Layer: *"Given that we're already using deck.gl
+we should try to understand if it could be feasible to replace Google
+version with it."* Co-locating both visualisation features under
+`src/Providers/Layers/deck.gl/` reduces the amount of Google-specific
+code and creates a consistent extension path for future Leaflet
+support.
+
+Additional constraints carried over from ADR-0003:
+
+- The replacement must work on top of Google Maps — the existing map
+  provider stays unchanged.
+- The framework layer (`src/OSFramework/Maps/FileLayer/`) must remain
+  provider-agnostic; the new implementation lives outside
+  `src/Providers/Maps/Google/`.
+- The legacy Google-native File Layer must be retained temporarily for
+  backward compatibility so developers can migrate at their own pace
+  before Google fully removes `KmlLayer`.
+- KML is published as `@loaders.gl/kml` on npm, ESM/CJS only — see
+  ADR-0005 for how that constraint is addressed.
+
+## Decision Drivers
+
+- Eliminate the dependency on the deprecated `google.maps.KmlLayer`
+  before Google removes it from active versions.
+- Allow client-side parsing so private/internal KML files load
+  successfully, removing the server-side `KmlLayer` parser's file-size
+  cap and public-URL requirement as a side benefit.
+- Keep changes transparent to OutSystems developers: the existing File
+  Layer block, its OnClick payload, and the
+  `MapAPI.FileLayerManager.CreateFileLayer` signature must continue to
+  work.
+- Align with ADR-0003: place client-side visualisation layers under the
+  same provider-agnostic deck.gl namespace.
+- Retain the legacy Google-native File Layer behind a flag so adopters
+  can fall back if a regression appears, until Google fully retires
+  `KmlLayer`.
+
+## Considered Options
+
+- **Option 1: Continue using `google.maps.KmlLayer`**
+  - Pros: No new dependency; no migration effort.
+  - Cons: The feature will stop working entirely once Google removes
+    `KmlLayer` from active versions following its April 30, 2026
+    deprecation. Inherits the existing limitations (server-side parse,
+    file-size cap, public-URL requirement). Permanently coupled to
+    Google Maps; no path toward provider-agnostic File Layer support.
+    Diverges from the direction set by ADR-0003 for the HeatmapLayer.
+
+- **Option 2: Migrate to Google's Data-driven Styling for Datasets**
+  - The first migration path Google itself recommends. KML data is
+    uploaded to the Maps Platform Datasets service and rendered through
+    the data-driven styling APIs.
+  - Pros: Officially supported by Google; survives the deprecation
+    timeline.
+  - Cons: Requires uploading every KML dataset to Google's
+    infrastructure ahead of time and managing dataset IDs at runtime —
+    a workflow change that is invasive for OutSystems developers and
+    incompatible with on-the-fly KML URLs that users currently pass to
+    the block. Adds a Google Maps Platform billing surface
+    (Datasets API). Still tightly coupled to Google Maps; no path
+    toward Leaflet support. Diverges from ADR-0003's
+    provider-abstraction direction.
+
+- **Option 3: deck.gl `GeoJsonLayer` + `@loaders.gl/kml` parser via `GoogleMapsOverlay`**
+  - The second migration path Google itself recommends (*"Use
+    third-party libraries to parse KML and display it using the Data
+    layer or other overlays."*). `@loaders.gl/kml` is the official KML
+    loader from the vis.gl ecosystem that also produces deck.gl. It
+    returns a GeoJSON `FeatureCollection` that feeds directly into
+    `deck.GeoJsonLayer`, which is then attached to the Google Map
+    through `deck.GoogleMapsOverlay` (the same mechanism used by the
+    HeatmapLayer per ADR-0003).
+  - Pros: Mature, GPU-accelerated rendering; preserves the existing
+    block API for OutSystems developers (consumer still passes a URL —
+    no dataset ingestion step); client-side parsing removes the
+    file-size cap and the public-URL requirement; consistent with the
+    HeatmapLayer architecture; opens a future migration path to Leaflet
+    through the same deck.gl overlays. Actively maintained by the
+    OpenJS Foundation (vis.gl).
+  - Cons: Adds a new third-party dependency (`@loaders.gl/kml`). The
+    loader is published only as ESM/CJS, so we must vendor it (see
+    ADR-0005). Property changes follow deck.gl's rebuild-and-setProps
+    pattern rather than incremental setters.
+
+## Decision Outcome
+
+Chosen option: **Option 3 — deck.gl `GeoJsonLayer` + `@loaders.gl/kml`**,
+because it is the only option that:
+
+1. Eliminates the dependency on the deprecated `KmlLayer` within the
+   required timeline without requiring OutSystems developers to change
+   how they author the File Layer block (the consumer still supplies a
+   plain URL, exactly as before).
+2. Co-locates the File Layer implementation with the HeatmapLayer under
+   a provider-agnostic deck.gl namespace, consistent with ADR-0003.
+3. Re-uses the same `GoogleMapsOverlay` integration mechanism that
+   ADR-0003 already validated for HeatmapLayer.
+4. Establishes a viable path toward Leaflet support for File Layer in
+   the future via deck.gl's Leaflet overlay — something neither
+   `KmlLayer` nor Google's Datasets approach can offer.
+5. Removes `KmlLayer`'s file-size cap and public-URL requirement as a
+   side benefit by parsing KML in the browser.
+
+Positive consequences:
+
+- File Layer can load larger files and files behind authentication that
+  `KmlLayer` could never render.
+- The OutSystems developer-facing API is unchanged. Existing applications
+  that use the File Layer block continue to work with no code changes.
+- The deck.gl File Layer lives in the same `src/Providers/Layers/deck.gl/`
+  namespace as the HeatmapLayer — future visualisation layers follow the
+  same shape.
+
+Negative consequences:
+
+- A new third-party stack (`@loaders.gl/kml` and the existing
+  `@deck.gl/*` packages) is now responsible for KML rendering. Upgrades to
+  this stack require coordinated maintenance, including a manual rebuild
+  of the vendored loaders.gl bundle (see ADR-0005).
+- Property changes (`layerUrl`, `suppressPopups`, `preserveViewport`) are
+  handled by recreating the deck.gl layer and calling
+  `overlay.setProps({ layers })`, rather than incremental setters. deck.gl's
+  internal diffing keeps the visual cost negligible.
+
+## Implementation Details
+
+### Coexistence strategy
+
+An `internalUseDeckglLoader` boolean was added to
+`OutSystems.Maps.MapAPI.FileLayerManager`, defaulting to `true`. The
+framework factory (`src/OSFramework/Maps/FileLayer/Factory.ts`) routes to
+either `Provider.Layers.deckgl.FileLayer.FileLayerFactory` (when the flag
+is true) or the legacy `Provider.Maps.Google.FileLayer.FileLayerFactory`
+(when it is false), based on the flag passed in by
+`FileLayerManager.CreateFileLayer`. The legacy Google-native File Layer
+is retained behind the flag for the same backward-compatibility window
+ADR-0003 established for HeatmapLayer; it will be removed in a future
+release once the deck.gl path is proven stable and Google fully retires
+`KmlLayer`.
+
+`MapAPI.FileLayerManager.SetUseDeckglLoader(false)` is the public escape
+hatch for falling back to the Google-native path.
+
+### Versioning
+
+Per the JIRA acceptance criteria, this change ships in OutSystems Maps
+**v2.4.0** (minor bump from v2.3.2). The deck.gl path is the default
+for new installations; existing applications inherit it on upgrade
+without any code change.
+
+### Namespace and file structure
+
+A new sub-namespace was introduced under `src/Providers/Layers/deck.gl/`:
+
+| File | Role |
+|---|---|
+| `FileLayer/FileLayer.ts` | Orchestrator. Loads the KML via the vendored loaders.gl bundle, builds the icon atlas, constructs a `deck.GeoJsonLayer`, wraps it in `deck.GoogleMapsOverlay`, and attaches it to the Google Map. Owns the property-change path (rebuild layer + setProps). |
+| `FileLayer/Factory.ts` | Factory method `MakeFileLayer()` that instantiates the deck.gl File Layer for the framework's Factory. |
+| `Configuration/FileLayer/FileLayerConfigs.ts` | Configuration class implementing `IConfigurationFileLayer` (`layerUrl`, `preserveViewport`, `suppressPopups`). |
+
+### Pipeline
+
+1. `_loadAndBuild()` calls `window.loaders.load(this.config.layerUrl, window.loaders.KMLLoader)` — the vendored loaders.gl bundle (see ADR-0005) parses the KML into a GeoJSON-shaped object (`{ shape: 'geojson-table', type: 'FeatureCollection', features: [...] }`).
+2. The orchestrator pre-builds an icon atlas from the features (see next section).
+3. `_buildProviderLayer()` constructs `deck.GeoJsonLayer` with `pointType: 'icon'`, the pre-built `iconAtlas` and `iconMapping`, plus pixel-unit fallback stroke/fill styles for any LineString/Polygon geometries the KML may contain.
+4. The layer is wrapped in a `deck.GoogleMapsOverlay` and attached to the map via `overlay.setMap(this.map.provider)`. If `preserveViewport` is `false`, the orchestrator walks the loaded features to compute bounds and calls `map.fitBounds(...)`.
+
+### Icon rendering — pre-built atlas (not deck.gl's URL auto-atlas)
+
+KML files reference icon images by URL inside each placemark's `<Style>`
+definition (e.g. Google's `mapfiles/kml/pushpin/ylw-pushpin.png`).
+`@loaders.gl/kml` surfaces these URLs as `feature.properties.icon`.
+
+deck.gl's `GeoJsonLayer` supports an automatic mode in which `getIcon`
+returns `{ url, width, height, anchor* }` per feature and deck.gl
+internally calls `@loaders.gl/core`'s `load(url)` to fetch and texture
+each icon. **This automatic mode does not work in this codebase.** The
+deck.gl runtime bundle carries its own copy of `@loaders.gl/core`,
+distinct from the vendored copy in `external_libs/loaders.gl` (ADR-0005).
+deck.gl's bundled core has no `ImageLoader` registered, so it throws:
+
+> `deck: No valid loader found (ylw-pushpin.png, MIME type: "image/png", first bytes: not available)`
+
+Registering `ImageLoader` against our vendored core does not help — the
+two loaders.gl/core instances have separate, module-scoped registries
+(the same multi-instance constraint noted in ADR-0005's rationale for
+keeping vendored libraries independent of the main pipeline).
+
+To bypass deck.gl's loader path entirely, the File Layer **pre-builds
+an icon atlas in the browser** before constructing the deck.gl layer:
+
+1. Walk the loaded features and collect unique `properties.icon` URLs
+   (trimmed). A default fallback URL is always included so features
+   without an explicit icon still render.
+2. Load each URL with a plain `new Image()` (`crossOrigin = 'anonymous'`),
+   wrapped in a Promise. Per-URL `try/catch` ensures one failed icon does
+   not block the layer.
+3. Composite successful loads into an offscreen `<canvas>` arranged as a
+   grid of 64 × 64 cells.
+4. Construct an `iconMapping` keyed by URL, with each entry providing
+   `x`, `y`, `width`, `height`, `anchorX`, `anchorY` (anchor at
+   bottom-centre, matching pushpin convention).
+5. Pass the canvas to `iconAtlas` and the mapping to `iconMapping` on
+   `GeoJsonLayer`. `getIcon` returns the URL string as the mapping key
+   (falling back to the default when no atlas entry exists for the
+   feature's URL).
+
+This approach is robust to whatever deck.gl bundle the OutSystems Forge
+component happens to load, because the layer never asks deck.gl to fetch
+icons — it hands deck.gl a finished texture.
+
+### Event flow
+
+Click events are routed through deck.gl's `onClick` callback on
+`GeoJsonLayer`. The handler stringifies `info.coordinate` (as
+`{Lat, Lng}`) and `info.object.properties` (as `featureData`) and fires
+the framework's `FileLayersEventType.OnClick` event with the same payload
+shape the legacy Google implementation produced. The
+`suppressPopups` config drives `pickable` on the deck.gl layer; the
+legacy `KmlMouseEvent.featureData` payload is replaced by the GeoJSON
+`properties` of the picked feature, which carries the same data
+(`name`, `description`, etc.) that consumers historically depended on.
+
+### Lifecycle
+
+- `build()` → `_loadAndBuild()` (async): fetch + parse KML, build atlas,
+  construct deck.gl layer + overlay, attach to map, optionally fit bounds,
+  then `finishBuild()`.
+- `changeProperty(layerUrl)` → tear down the overlay, clear the atlas,
+  re-run `_loadAndBuild(false)` with the new URL.
+- `changeProperty(suppressPopups)` → rebuild the layer and call
+  `overlay.setProps({ layers })`; atlas state is preserved.
+- `changeProperty(preserveViewport)` → invoke `_fitBounds()` when the new
+  value is `false`.
+- `dispose()` → detach the overlay, finalise deck.gl resources, clear all
+  retained state (`_provider`, `_geoJsonLayer`, `_geoJsonData`,
+  `_iconAtlas`, `_iconMapping`).
+
+### Dependency on ADR-0005
+
+The vendored `external_libs/loaders.gl` bundle is the **first consumer**
+of the pattern documented in ADR-0005 and is what makes this File Layer
+implementation possible. `@loaders.gl/kml` v4.4.2 is published only as
+ESM/CJS — without the `external_libs/loaders.gl` UMD bundle exposing
+`window.loaders.load` and `window.loaders.KMLLoader`, this option would
+not have been buildable. Any future change to the KML parser version,
+or addition of further loaders.gl modules (e.g. GPX), follows the
+rebuild process described in ADR-0005.
+
+## Links
+
+- ROU-12785 — Spike: *[OSMaps] - Investigate how to replace KmlLayer that Google deprecated by deck.gl*
+- ROU-3078 — parent epic: *OutSystems Maps*
+- [ADR-0003: Replace Google HeatmapLayer with deck.gl HeatmapLayer](./ADR-0003-Replace-Google-HeatmapLayer-with-deck-gl.md)
+- [ADR-0005: Self-Contained Bundling of NPM-Only Runtime Libraries via external_libs Folder](./ADR-0005-Self-Contained-Bundling-of-NPM-Only-Runtime-Libraries.md)
+- [Google Maps Platform deprecations](https://developers.google.com/maps/deprecations)
+- [Google KML Layer Migration Guide](https://developers.google.com/maps/documentation/javascript/kml-layer-migration)
+- [Google Maps Datasets overview](https://developers.google.com/maps/documentation/javascript/dds-datasets/overview)
+- [deck.gl GeoJsonLayer API](https://deck.gl/docs/api-reference/layers/geojson-layer)
+- [deck.gl GoogleMapsOverlay](https://deck.gl/docs/api-reference/google-maps/google-maps-overlay)
+- [@loaders.gl/kml API reference](https://loaders.gl/docs/modules/kml/api-reference/kml-loader)
+
+## Date
+
+2026-05-19

--- a/docs/adr/Readme.md
+++ b/docs/adr/Readme.md
@@ -24,8 +24,12 @@ Each ADR should follow the template in `ADR-0000-Title-of-ADR.md`.
 
 ## ADR Log
 
-| ADR Number | Title                                                             | Status   | Date                                |
-| :--------- | :---------------------------------------------------------------- | :------- | :---------------------------------- |
-| ADR-0000   | Template for ADRs                                                 | Meta     | 2026-02-04                          |
-| ADR-0001   | Use AI for Development Assistance                                 | Accepted | 2026-02-04                          |
-| ADR-0002   | Highcharts TypeScript typings compatibility fixes v12 Assistance                                 | Accepted | 2026-02-04                          |
+| ADR Number | Title                                                                                  | Status   | Date       |
+| :--------- | :------------------------------------------------------------------------------------- | :------- | :--------- |
+| [ADR-0000](./ADR-0000-Title-of-ADR.md) | Template for ADRs                                                          | Meta     | —          |
+| [ADR-0001](./ADR-0001-Google-Markers-Draw-Performance.md) | Google Markers and Marker Cluster draw phase            | Accepted | 2026-02-10 |
+| [ADR-0002](./ADR-0002-Replace-Google-DrawingManager-with-TerraDraw.md) | Replace Google DrawingManager with Terra Draw | Accepted | 2026-03-17 |
+| [ADR-0003](./ADR-0003-Replace-Google-HeatmapLayer-with-deck-gl.md) | Replace Google HeatmapLayer with deck.gl HeatmapLayer | Accepted | 2026-04-07 |
+| [ADR-0004](./ADR-0004-Fix-RespectUserZoom-Only-Breaking-Map-Center-Refresh.md) | Fix map center not refreshing when only respectUserZoom is active | Accepted | 2026-04-20 |
+| [ADR-0005](./ADR-0005-Self-Contained-Bundling-of-NPM-Only-Runtime-Libraries.md) | Self-contained bundling of npm-only runtime libraries via external_libs folder | Proposed | 2026-05-19 |
+| [ADR-0006](./ADR-0006-Replace-Google-KmlLayer-with-deck-gl-FileLayer.md) | Replace Google KmlLayer with deck.gl-based FileLayer | Proposed | 2026-05-19 |


### PR DESCRIPTION
This pull request adds two new Architecture Decision Records (ADRs) that document the proposed changes to address the deprecation of the feature. These ADRs formalize both the rationale and implementation details for handling third-party dependencies and for replacing deprecated features with a more flexible, provider-agnostic architecture.

### What was happening
* Google deprecated `google.maps.KmlLayer` on **April 30, 2026**. Per the official deprecation notice and KML Layer Migration Guide, the class remains available for existing applications but is closed to new projects and will be subject to removal at a future date.

### What was done
* Designed the proposed approach is to implement the functionality using deck.gl external library, together with additional deck.gl modules.
* Created 2 ADR files that document the technical decisions:
   * **ADR-0005: Bundling npm-only runtime libraries** - Introduces ADR-0005, which describes a pattern for vendoring npm-only libraries (those published only as ESM/CJS) by bundling them into self-contained subfolders under `external_libs/`. Each library gets its own build and output, ensuring reproducibility, version pinning, and isolation from the main TypeScript build pipeline. This enables browser runtime use of libraries like `@loaders.gl/kml` without introducing a runtime bundler or external CDN dependencies.
   *  **ADR-0006: Migration from Google KmlLayer to deck.gl FileLayer** - documenting the replacement of the deprecated `google.maps.KmlLayer` with a deck.gl-based FileLayer. The new implementation parses KML files client-side using the vendored loaders.gl bundle, renders them via `deck.GeoJsonLayer` and `GoogleMapsOverlay`, and maintains backward compatibility for OutSystems developers. The ADR details the technical rationale, coexistence strategy, icon rendering pipeline, and event handling, ensuring a smooth migration path and future extensibility.

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

