### PR TITLE
ROU-12857: Ensure directions waypoints are always defined

### DIFF
--- a/src/Providers/Maps/Google/Features/Directions.ts
+++ b/src/Providers/Maps/Google/Features/Directions.ts
@@ -22,6 +22,7 @@ namespace Provider.Maps.Google.Feature {
 			this._currRouteTime = 0;
 			this._currRouteLegs = [];
 			this._retriveLegsFromRoute = false;
+			this._waypoints = [];
 			this._directionsRenderer = new DirectionsRenderer(map);
 		}
 
@@ -71,7 +72,7 @@ namespace Provider.Maps.Google.Feature {
 		): Types.RoutesRequestBody {
 			const isOriginCoordinate = Helper.TypeChecker.IsValidCoordinates(directionOptions.originRoute);
 			const isDestinationCoordinate = Helper.TypeChecker.IsValidCoordinates(directionOptions.destinationRoute);
-			this._waypoints = directionOptions.waypoints;
+			this._waypoints = directionOptions.waypoints ?? [];
 
 			const requestBody: Types.RoutesRequestBody = {
 				origin: {
@@ -90,7 +91,7 @@ namespace Provider.Maps.Google.Feature {
 						: undefined,
 					address: isDestinationCoordinate ? undefined : directionOptions.destinationRoute,
 				},
-				intermediates: this._waypointsCleanup(directionOptions.waypoints),
+				intermediates: this._waypointsCleanup(this._waypoints),
 				travelMode: this._convertTravelMode(directionOptions.travelMode),
 				routingPreference: directionOptions.travelMode === 'DRIVING' ? 'TRAFFIC_UNAWARE' : undefined,
 				routeModifiers: {


### PR DESCRIPTION
This PR is to improve the directions waypoints instantiation to ensure it is never undefined.

### What was happening
* When the user tried to remove routes without adding them first, the waypoints array was undefined
* The access to the waypoint length when the waypoints were undefined raised an error

### What was done
* In the instantiation of the waypoint, an empty array is used the value is undefined

### Test Steps
1. Open the sample application
2. Open the development tools
3. Validate that no error is visible on the console

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

