### PR TITLE
ROU-11724: Update TypeScript and Typedoc to use the latest stable versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ code/*.bat
 code/package-lock.json
 package-lock.json
 
+# Generated TypeDoc output (keep static files)
+docs/*
 !docs/Licenses
 !docs/README.md
 !external_libs/**/dist

--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
     "stylelint-config-prettier": "^9.0.5",
     "stylelint-order": "^6.0.4",
     "terra-draw": "1.25.0",
-    "typedoc": "^0.23.28",
-    "typedoc-plugin-merge-modules": "^4.1.0",
-    "typedoc-umlclass": "^0.7.1",
-    "typescript": "^4.9.5"
+    "typedoc": "^0.28.19",
+    "typedoc-plugin-merge-modules": "^7.0.0",
+    "typedoc-umlclass": "^0.10.2",
+    "typescript": "^5.9.3"
   },
   "volta": {
     "node": "24.13.1",

--- a/src/Providers/Maps/Google/Style.ts
+++ b/src/Providers/Maps/Google/Style.ts
@@ -50,6 +50,6 @@ namespace Provider.Maps.Google {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		const style = Style[OSFramework.Maps.Enum.OSMap.Style[id - 1]].style.replace(/'/g, '"');
 		// Parse to JSON and return the value
-		return style !== '' ? JSON.parse(style) : '';
+		return style !== '' ? JSON.parse(style) : [];
 	}
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,11 +5,43 @@
         "./src/Providers/Maps/**/*.ts"
     ],
     "entryPointStrategy": "expand",
+    "plugin": [
+        "typedoc-umlclass",
+        "typedoc-plugin-merge-modules"
+    ],
     "includeVersion": true,
     "hideGenerator": true,
     "out": "./docs/files",
     "sort": [
         "source-order"
+    ],
+    "blockTags": [
+        "@alpha",
+        "@beta",
+        "@defaultValue",
+        "@deprecated",
+        "@example",
+        "@experimental",
+        "@internal",
+        "@override",
+        "@param",
+        "@privateRemarks",
+        "@public",
+        "@remarks",
+        "@returns",
+        "@sealed",
+        "@see",
+        "@throws",
+        "@virtual",
+        "@memberof",
+        "@export",
+        "@static",
+        "@todo",
+        "@return",
+        "@extends",
+        "@template",
+        "@type",
+        "@implements"
     ],
     "umlClassDiagram": {
         "type": "detailed",
@@ -21,4 +53,9 @@
         "arrowColor": "#272b30"
     },
     "customCss": "typedoc-custom.css",
+    "validation": {
+        "notExported": false,
+        "invalidLink": true,
+        "notDocumented": false
+    }
 }


### PR DESCRIPTION
### What was done
* update typescript, typedoc and its plugins;
* fix typescript error;

### Test Steps
1. Run npm run docs and check there are no errors.


### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

