### PR TITLE
ROU-12855: V2 Resolve Github Actions deprecation warnings for Node 20

### DIFF
--- a/.github/actions/az-keyvault-get/action.yml
+++ b/.github/actions/az-keyvault-get/action.yml
@@ -65,16 +65,14 @@ inputs:
 outputs:
     az-keyvault-value:
         description: 'The Azure key value.'
-        value: ${{ steps.GetAzKeyVaultSecret.outputs.az-keyvault-secret }}
+        value: ${{ steps.GetAzKeyVaultSecret.outputs.az-keyvault-value }}
 
 runs:
     using: composite
     steps:
         - name: Azure KeyVault get Value
-          uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
+          uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
           id: GetAzKeyVaultSecret
           with:
-              inlineScript: |
-                  secretValue=$(az keyvault secret show --name "${{ inputs.key-name }}" --vault-name "${{ inputs.keyvault-name }}" --query "value" --output tsv)
-                  echo "::add-mask::$secretValue"
-                  echo "az-keyvault-secret=$secretValue" >> $GITHUB_OUTPUT
+              keyvault-name: ${{ inputs.keyvault-name }}
+              key-name: ${{ inputs.key-name }}

--- a/.github/actions/az-login/action.yml
+++ b/.github/actions/az-login/action.yml
@@ -43,7 +43,7 @@ runs:
     using: composite
     steps:
         - name: Azure DevOps Login
-          uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+          uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
           with:
               client-id: ${{ inputs.client-id }}
               tenant-id: ${{ inputs.tenant-id }}

--- a/.github/actions/validate-pr-title/action.yml
+++ b/.github/actions/validate-pr-title/action.yml
@@ -37,7 +37,7 @@ runs:
   using: composite
   steps:
     - name: "Check PR title follows '${{ inputs.validate-semVer == true && '+semver: <minor|major|patch> ' || '' }}<ticket id> <description>'"
-      uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 #v1.0.2
+      uses: OutSystems/rd.github-reusable-workflows/.github/actions/validate-pr-title@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
       with:
-        regex: ^${{ inputs.validate-semVer == true && '(\+semver:\s(minor|major|patch)\s)?' || '' }}([A-Z][A-Z0-9]*-\d+(:)?\s\w)
+        validate-semVer: ${{ inputs.validate-semVer }}
       if: ${{ contains(github.head_ref, 'release/') == false && contains(github.head_ref, 'merge/') == false }}

--- a/.github/workflows/template-pre-release.yaml
+++ b/.github/workflows/template-pre-release.yaml
@@ -107,7 +107,7 @@ jobs:
 
             - name: 🔐 Azure login
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-login
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   client-id: ${{ secrets.OSUI_AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.OSUI_AZURE_TENANT_ID }}
@@ -116,7 +116,7 @@ jobs:
             - name: 🔑 Get GitHub Token
               id: get-github-token
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-keyvault-get
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   key-name: o11odc-github-gitpersonal-token-prd
 
@@ -158,7 +158,7 @@ jobs:
 
             - name: 🔐 Azure login
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-login
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   client-id: ${{ secrets.OSUI_AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.OSUI_AZURE_TENANT_ID }}
@@ -167,7 +167,7 @@ jobs:
             - name: 🔑 Get GitHub Token
               id: get-github-token
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-keyvault-get
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   key-name: o11odc-github-gitpersonal-token-prd
 
@@ -197,7 +197,7 @@ jobs:
 
             - name: 🔐 Azure login
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-login
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   client-id: ${{ secrets.OSUI_AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.OSUI_AZURE_TENANT_ID }}
@@ -206,7 +206,7 @@ jobs:
             - name: 🔑 Get GitHub Token
               id: get-github-token
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-keyvault-get
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   key-name: o11odc-github-gitpersonal-token-prd
 
@@ -237,7 +237,7 @@ jobs:
 
             - name: 🔐 Azure login
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-login
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   client-id: ${{ secrets.OSUI_AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.OSUI_AZURE_TENANT_ID }}
@@ -246,7 +246,7 @@ jobs:
             - name: 🔑 Get GitHub Token
               id: get-github-token
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-keyvault-get
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   key-name: o11odc-github-gitpersonal-token-prd
 
@@ -288,7 +288,7 @@ jobs:
 
             - name: 🔐 Azure login
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-login
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   client-id: ${{ secrets.OSUI_AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.OSUI_AZURE_TENANT_ID }}
@@ -297,7 +297,7 @@ jobs:
             - name: 🔑 Get GitHub Token
               id: get-github-token
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-keyvault-get
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   key-name: o11odc-github-gitpersonal-token-prd
           
@@ -347,7 +347,7 @@ jobs:
             - name: 🔑 Get GPG Passphrase from Azure Key Vault
               id: GetGPGPassphrase
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-keyvault-get
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   key-name: o11odc-github-gpg-passphrase-prd
 

--- a/.github/workflows/template-release.yaml
+++ b/.github/workflows/template-release.yaml
@@ -91,7 +91,7 @@ jobs:
 
             - name: 🔐 Azure login
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-login
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   client-id: ${{ secrets.OSUI_AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.OSUI_AZURE_TENANT_ID }}
@@ -100,7 +100,7 @@ jobs:
             - name: 🔑 Get GitHub Token
               id: get-github-token
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-keyvault-get
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   key-name: o11odc-github-gitpersonal-token-prd
 
@@ -126,7 +126,7 @@ jobs:
 
             - name: 🔐 Azure login
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-login
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   client-id: ${{ secrets.OSUI_AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.OSUI_AZURE_TENANT_ID }}
@@ -135,7 +135,7 @@ jobs:
             - name: 🔑 Get GitHub Token
               id: get-github-token
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-keyvault-get
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   key-name: o11odc-github-gitpersonal-token-prd
 

--- a/.github/workflows/template-ts-build-project.yaml
+++ b/.github/workflows/template-ts-build-project.yaml
@@ -79,7 +79,7 @@ jobs:
 
             - name: 🔐 Azure login
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-login
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-login@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   client-id: ${{ secrets.OSUI_AZURE_CLIENT_ID }}
                   tenant-id: ${{ secrets.OSUI_AZURE_TENANT_ID }}
@@ -89,7 +89,7 @@ jobs:
               id: get-sonarcloud-token
               if: ${{ inputs.run-sonarcloud == true }}
               #uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@9d497d1c5bc6e355aa8f4663539e6b75c212f6b4 #v2.0.7
-              uses: ./.github/actions/az-keyvault-get
+              uses: OutSystems/rd.github-reusable-workflows/.github/actions/az-keyvault-get@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
               with:
                   key-name: o11odc-github-sonarcloud-token-prd
 

--- a/.github/workflows/template-validate-pr-title.yaml
+++ b/.github/workflows/template-validate-pr-title.yaml
@@ -45,11 +45,7 @@ jobs:
     name: Check PR title
     runs-on: ubuntu-latest
     steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
       - name: "🔎 Check PR title follows '${{ inputs.validate-semVer == true && '+semver: <minor|major|patch> ' || '' }}<ticket id> <description>'"
-        #uses: OutSystems/rd.github-reusable-workflows/.github/actions/validate-pr-title@v2.0.7
-        uses: ./.github/actions/validate-pr-title
+        uses: OutSystems/rd.github-reusable-workflows/.github/actions/validate-pr-title@c8485a9aece78d1de3c56451a0a7a2cab0fb3212 #v2.0.9
         with:
-          validate-semVer: ${{ inputs.validate-semVer }}        
+          validate-semVer: ${{ inputs.validate-semVer }}


### PR DESCRIPTION
### What was done
* update rd.github-reusable-workflows usage;
* remove direct third party actions and use the one from rd.github-reusable-workflows;

### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

